### PR TITLE
Respect configured instrument subsets

### DIFF
--- a/src/decision_engine.py
+++ b/src/decision_engine.py
@@ -162,8 +162,14 @@ class DecisionEngine:
         resolved: List[str] = []
         seen = set()
 
-        if configured:
-            for entry in configured:
+        if configured is not None:
+            entries: Iterable[str]
+            if isinstance(configured, str):
+                entries = [configured]
+            else:
+                entries = configured
+
+            for entry in entries:
                 if not isinstance(entry, str):
                     continue
                 symbol = entry.strip().upper()
@@ -171,11 +177,13 @@ class DecisionEngine:
                     continue
                 resolved.append(symbol)
                 seen.add(symbol)
+            return resolved
 
         for symbol in DEFAULT_INSTRUMENTS:
-            if symbol not in seen:
-                resolved.append(symbol)
-                seen.add(symbol)
+            if symbol in seen:
+                continue
+            resolved.append(symbol)
+            seen.add(symbol)
 
         return resolved
 

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -93,6 +93,61 @@ def test_scans_all_instruments(capfd, sample_config):
         assert any(f"[DECISION] {instrument} signal=" in line for line in decision_lines)
 
 
+def test_respects_configured_instrument_subset(capfd, sample_config):
+    subset = ["EUR_USD", "USD_JPY"]
+    config = dict(sample_config)
+    config["instruments"] = subset
+
+    prices: Dict[str, List[Dict[str, float]]] = {
+        symbol: [
+            {"o": 1.0, "h": 1.0, "l": 1.0, "c": 1.0},
+            {"o": 1.0, "h": 1.0, "l": 1.0, "c": 1.0},
+            {"o": 1.0, "h": 1.0, "l": 1.0, "c": 1.0},
+        ]
+        for symbol in subset
+    }
+
+    def fetcher(instrument: str, **kwargs):
+        return prices[instrument]
+
+    engine = DecisionEngine(config, candle_fetcher=fetcher, now_fn=lambda: datetime.now(timezone.utc))
+    evaluations = engine.evaluate_all()
+
+    assert [ev.instrument for ev in evaluations] == subset
+
+    captured = capfd.readouterr()
+    output_lines = captured.out.splitlines()
+    scan_lines = [line for line in output_lines if line.startswith("[SCAN]")]
+    decision_lines = [line for line in output_lines if line.startswith("[DECISION]")]
+
+    assert len(scan_lines) == len(subset)
+    assert len(decision_lines) == len(subset)
+
+    for instrument in subset:
+        assert any(f"[SCAN] Evaluating {instrument}" in line for line in scan_lines)
+        assert any(f"[DECISION] {instrument} signal=" in line for line in decision_lines)
+
+
+def test_allows_empty_instrument_configuration(capfd, sample_config):
+    config = dict(sample_config)
+    config["instruments"] = []
+
+    calls: List[str] = []
+
+    def fetcher(instrument: str, **kwargs):  # pragma: no cover - defensive
+        calls.append(instrument)
+        return []
+
+    engine = DecisionEngine(config, candle_fetcher=fetcher, now_fn=lambda: datetime.now(timezone.utc))
+    evaluations = engine.evaluate_all()
+
+    assert evaluations == []
+    assert calls == []
+
+    captured = capfd.readouterr()
+    assert captured.out.strip() == ""
+
+
 def test_skips_inactive_markets(capfd, sample_config):
     def fetcher(instrument: str, **kwargs):
         return [{"o": 1.0, "h": 1.0, "l": 1.0, "c": None}]
@@ -104,11 +159,13 @@ def test_skips_inactive_markets(capfd, sample_config):
     assert all(ev.signal == "HOLD" for ev in evaluations)
 
     captured = capfd.readouterr()
-    output_lines = [line for line in captured.out.splitlines() if line.startswith("[SCAN]")]
-    assert len(output_lines) == len(sample_config["instruments"])
-    assert all("signal=HOLD" in line for line in output_lines)
-    assert all("rsi=n/a" in line for line in output_lines)
-    assert all("atr=n/a" in line for line in output_lines)
+    scan_lines = [line for line in captured.out.splitlines() if line.startswith("[SCAN]")]
+    decision_lines = [line for line in captured.out.splitlines() if line.startswith("[DECISION]")]
+    assert len(scan_lines) == len(sample_config["instruments"])
+    assert len(decision_lines) == len(sample_config["instruments"])
+    assert all("rsi=n/a" in line for line in scan_lines)
+    assert all("atr=n/a" in line for line in scan_lines)
+    assert all("signal=HOLD" in line for line in decision_lines)
 
 
 def test_decision_cycle_updates_watchdog_on_success(monkeypatch):


### PR DESCRIPTION
## Summary
- ensure the decision engine only falls back to default instruments when the configuration omits instruments entirely
- respect explicitly empty instrument configurations by returning no instruments
- add regression coverage for instrument subset handling, empty configurations, and adjust inactive market logging assertions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e79349bc208329bfdbc1e9ddcc6134