### PR TITLE
Document Render rollback limitation

### DIFF
--- a/docs/rollback_attempt.md
+++ b/docs/rollback_attempt.md
@@ -1,0 +1,5 @@
+# Rollback Attempt Log
+
+The Render CLI is not available in the current environment, so the rollback commands could not be executed. The required command `render deploys:list` returned `command not found`.
+
+Please install the Render CLI or run the rollback from an environment with access to the tool.


### PR DESCRIPTION
## Summary
- add a rollback attempt log explaining that the Render CLI is unavailable in the current environment

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ea1874b2e083299f79838a5d664d35