### PR TITLE
Add debug print for trailing profit tracking

### DIFF
--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -50,6 +50,10 @@ class ProfitProtection:
                 self._high_water[instrument] = profit
                 high_water = profit
 
+            print(
+                f"[TRAIL-DEBUG] profit={profit:.2f} high_water={high_water:.2f}",
+                flush=True,
+            )
             if (
                 high_water >= self.trigger
                 and profit <= high_water - self.trail


### PR DESCRIPTION
## Summary
- add a trailing profit debug print to display profit and high-water mark before applying the trailing exit rule

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f89a875c9483298e4521a72f1c42c7