### PR TITLE
Add debug log for profit protection loop

### DIFF
--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -36,6 +36,13 @@ class ProfitProtection:
         closed_instruments: List[str] = []
 
         for trade in open_trades:
+            label: str
+            if isinstance(trade, dict):
+                label = str(trade.get("instrument") or "<unknown>")
+            else:
+                label = str(trade)
+            print(f"[CHECK-DEBUG] Checking {label}", flush=True)
+
             instrument = self._instrument_from_trade(trade)
             if not instrument:
                 continue
@@ -50,6 +57,10 @@ class ProfitProtection:
                 self._high_water[instrument] = profit
                 high_water = profit
 
+            print(
+                f"[TRAIL-DEBUG] profit={profit:.2f} high_water={high_water:.2f}",
+                flush=True,
+            )
             if (
                 high_water >= self.trigger
                 and profit <= high_water - self.trail


### PR DESCRIPTION
## Summary
- log a [CHECK-DEBUG] message for each open trade processed by the trailing rule

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f89a875c9483298e4521a72f1c42c7