### PR TITLE
Add workflow to run finish_render_setup script

### DIFF
--- a/.github/workflows/finish-render-setup.yml
+++ b/.github/workflows/finish-render-setup.yml
@@ -1,0 +1,41 @@
+name: Finish Render Setup
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-finish-render-setup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run finish_render_setup.py
+        env:
+          RENDER_API_TOKEN: ${{ secrets.RENDER_API_TOKEN }}
+          MCP_API_KEY: ${{ secrets.MCP_API_KEY }}
+          GH_PAT: ${{ secrets.GH_PAT }}
+          RENDER_DEPLOY_HOOK_URL: ${{ secrets.RENDER_DEPLOY_HOOK_URL }}
+        run: |
+          set -e
+          python finish_render_setup.py
+
+      - name: Success message
+        if: success()
+        run: echo "✅ Render services live and GitHub workflow dispatched."
+
+      - name: Failure summary
+        if: failure()
+        run: |
+          echo "finish_render_setup.py failed. Review logs for HTTP error details."
+          exit 1

--- a/deploy_mcp.py
+++ b/deploy_mcp.py
@@ -1,0 +1,251 @@
+import json
+import os
+import sys
+import time
+from typing import Dict, Iterable, Tuple
+
+import requests
+
+RENDER_APPLY_URL = "https://api.render.com/v1/blueprints/apply"
+RENDER_SERVICE_URL = "https://api.render.com/v1/services/{service_id}"
+GITHUB_DISPATCH_URL = (
+    "https://api.github.com/repos/lukeblanc/mossy-4x-render/actions/workflows/auto-mossy.yml/dispatches"
+)
+POLL_INTERVAL_SECONDS = 20
+WAIT_TIMEOUT_SECONDS = 30 * 60
+
+
+def mask_token(token: str) -> str:
+    if not token:
+        return ""
+    if len(token) <= 8:
+        return "*" * len(token)
+    return f"{token[:4]}{'*' * (len(token) - 8)}{token[-4:]}"
+
+
+def sanitize(text: str, replacements: Dict[str, str]) -> str:
+    sanitized = text
+    for original, masked in replacements.items():
+        if original:
+            sanitized = sanitized.replace(original, masked)
+    return sanitized
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"Missing required environment variable: {name}")
+    return value
+
+
+def apply_blueprint(render_token: str, blueprint_content: str) -> Dict[str, object]:
+    headers = {
+        "Authorization": f"Bearer {render_token}",
+        "Content-Type": "application/x-yaml",
+        "Accept": "application/json",
+    }
+    response = requests.post(
+        RENDER_APPLY_URL,
+        data=blueprint_content.encode("utf-8"),
+        headers=headers,
+        timeout=30,
+    )
+    response.raise_for_status()
+    if not response.text:
+        return {}
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return {}
+
+
+def extract_services(apply_result: Dict[str, object]) -> Dict[str, str]:
+    services: Dict[str, str] = {}
+
+    def ingest_service_entries(entries: Iterable[object]) -> None:
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            service_data = entry
+            if "service" in entry and isinstance(entry["service"], dict):
+                service_data = entry["service"]
+            name = service_data.get("name") if isinstance(service_data, dict) else None
+            service_id = service_data.get("id") if isinstance(service_data, dict) else None
+            if not service_id and isinstance(entry, dict):
+                service_id = entry.get("id") or entry.get("serviceId") or entry.get("serviceID")
+            if name and service_id:
+                services[name] = service_id
+
+    if not isinstance(apply_result, dict):
+        return services
+
+    if "services" in apply_result and isinstance(apply_result["services"], list):
+        ingest_service_entries(apply_result["services"])
+
+    if "resources" in apply_result and isinstance(apply_result["resources"], list):
+        ingest_service_entries(apply_result["resources"])
+
+    blueprint = apply_result.get("blueprint")
+    if isinstance(blueprint, dict):
+        if "services" in blueprint and isinstance(blueprint["services"], list):
+            ingest_service_entries(blueprint["services"])
+        if "resources" in blueprint and isinstance(blueprint["resources"], list):
+            ingest_service_entries(blueprint["resources"])
+
+    if not services:
+        service_ids = apply_result.get("serviceIds")
+        if isinstance(service_ids, list):
+            for index, service_id in enumerate(service_ids, start=1):
+                if isinstance(service_id, str):
+                    services[f"service_{index}"] = service_id
+
+    return services
+
+
+def fetch_service_status(render_token: str, service_id: str) -> Tuple[str, str]:
+    headers = {
+        "Authorization": f"Bearer {render_token}",
+        "Accept": "application/json",
+    }
+    response = requests.get(
+        RENDER_SERVICE_URL.format(service_id=service_id),
+        headers=headers,
+        timeout=30,
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    status = None
+    name = None
+    if isinstance(data, dict):
+        if "service" in data and isinstance(data["service"], dict):
+            service_block = data["service"]
+            status = service_block.get("status")
+            name = service_block.get("name")
+        else:
+            status = data.get("status")
+            name = data.get("name")
+        if not status and isinstance(data.get("deployment"), dict):
+            status = data["deployment"].get("status")
+    return (status or "unknown", name or "")
+
+
+def wait_for_services_live(render_token: str, services: Dict[str, str]) -> None:
+    start_time = time.monotonic()
+    while True:
+        statuses = {}
+        for name, service_id in services.items():
+            status, reported_name = fetch_service_status(render_token, service_id)
+            display_name = reported_name or name
+            statuses[display_name] = status
+        if all(status.lower() == "live" for status in statuses.values()):
+            break
+        elapsed = time.monotonic() - start_time
+        if elapsed > WAIT_TIMEOUT_SECONDS:
+            status_line = ", ".join(f"{svc}={state}" for svc, state in statuses.items())
+            raise TimeoutError(f"Timed out waiting for services to become live ({status_line}).")
+        status_line = ", ".join(f"{svc}={state}" for svc, state in statuses.items())
+        print(f"Waiting for services: {status_line}")
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def dispatch_github_workflow(gh_pat: str) -> None:
+    headers = {
+        "Authorization": f"Bearer {gh_pat}",
+        "Accept": "application/vnd.github+json",
+    }
+    response = requests.post(
+        GITHUB_DISPATCH_URL,
+        headers=headers,
+        json={"ref": "main"},
+        timeout=30,
+    )
+    response.raise_for_status()
+
+
+def print_http_error(prefix: str, response: requests.Response, replacements: Dict[str, str]) -> None:
+    status = response.status_code
+    try:
+        detail = json.dumps(response.json(), indent=2)
+    except ValueError:
+        detail = response.text
+    message = f"{prefix}: HTTP {status} - {detail}"
+    print(sanitize(message, replacements))
+
+
+def main() -> None:
+    try:
+        render_api_token = require_env("RENDER_API_TOKEN")
+        mcp_api_key = require_env("MCP_API_KEY")
+        gh_pat = require_env("GH_PAT")
+        render_deploy_hook_url = require_env("RENDER_DEPLOY_HOOK_URL")
+    except ValueError as exc:
+        print(exc)
+        sys.exit(1)
+
+    replacements = {
+        render_api_token: mask_token(render_api_token),
+        mcp_api_key: mask_token(mcp_api_key),
+        gh_pat: mask_token(gh_pat),
+        render_deploy_hook_url: mask_token(render_deploy_hook_url),
+    }
+
+    try:
+        blueprint_content = open("mcp/render.yaml", "r", encoding="utf-8").read()
+    except OSError as exc:
+        print(sanitize(f"Failed to read blueprint file: {exc}", replacements))
+        sys.exit(1)
+
+    try:
+        apply_result = apply_blueprint(render_api_token, blueprint_content)
+    except requests.HTTPError as exc:
+        response = exc.response
+        if response is not None:
+            print_http_error("Render blueprint apply failed", response, replacements)
+        else:
+            print(sanitize(f"Render blueprint apply failed: {exc}", replacements))
+        sys.exit(1)
+    except requests.RequestException as exc:
+        print(sanitize(f"Render blueprint apply request error: {exc}", replacements))
+        sys.exit(1)
+
+    services = extract_services(apply_result)
+    if not services:
+        print("Render blueprint applied but no services were returned in the response.")
+        sys.exit(1)
+
+    print("Render blueprint applied; waiting for services to reach 'live' status...")
+    try:
+        wait_for_services_live(render_api_token, services)
+    except TimeoutError as exc:
+        print(sanitize(str(exc), replacements))
+        sys.exit(1)
+    except requests.HTTPError as exc:
+        response = exc.response
+        if response is not None:
+            print_http_error("Failed to fetch Render service status", response, replacements)
+        else:
+            print(sanitize(f"Failed to fetch Render service status: {exc}", replacements))
+        sys.exit(1)
+    except requests.RequestException as exc:
+        print(sanitize(f"Error while polling Render services: {exc}", replacements))
+        sys.exit(1)
+
+    try:
+        dispatch_github_workflow(gh_pat)
+    except requests.HTTPError as exc:
+        response = exc.response
+        if response is not None:
+            print_http_error("GitHub workflow dispatch failed", response, replacements)
+        else:
+            print(sanitize(f"GitHub workflow dispatch failed: {exc}", replacements))
+        sys.exit(1)
+    except requests.RequestException as exc:
+        print(sanitize(f"GitHub workflow dispatch error: {exc}", replacements))
+        sys.exit(1)
+
+    print("✅ MCP deployed & workflow dispatched")
+
+
+if __name__ == "__main__":
+    main()

--- a/finish_autotune.py
+++ b/finish_autotune.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import base64
+import sys
+from getpass import getpass
+from typing import Tuple
+
+import requests
+from nacl import encoding, public
+
+GITHUB_API_BASE = "https://api.github.com"
+REPO = "lukeblanc/mossy-4x-render"
+SECRET_NAME = "GH_PAT"
+REQUEST_TIMEOUT = 30
+API_VERSION = "2022-11-28"
+
+
+def mask_pat(token: str) -> str:
+    """Return a masked representation of a GitHub PAT."""
+
+    if token.startswith("ghp_"):
+        tail = token[-4:] if len(token) > 4 else ""
+        return f"ghp_{'*' * 8}{tail}"
+    if len(token) <= 4:
+        return "*" * len(token)
+    return f"{'*' * 4}{token[-4:]}"
+
+
+def authorization_headers(token: str) -> dict[str, str]:
+    """Headers for authenticated GitHub API requests."""
+
+    return {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": API_VERSION,
+    }
+
+
+def finish_pat_authorization(token: str, otp_code: str) -> None:
+    """Send the one-time password to finalize PAT authorization."""
+
+    url = f"{GITHUB_API_BASE}/authorizations"
+    payload = {"one_time_password": otp_code}
+    response = requests.post(
+        url,
+        headers=authorization_headers(token),
+        json=payload,
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+
+
+def get_repo_public_key(token: str) -> Tuple[str, str]:
+    """Fetch the repository's public key and key ID."""
+
+    url = f"{GITHUB_API_BASE}/repos/{REPO}/actions/secrets/public-key"
+    response = requests.get(
+        url,
+        headers=authorization_headers(token),
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload["key"], payload["key_id"]
+
+
+def encrypt_secret(secret_value: str, public_key: str) -> str:
+    """Encrypt a secret using GitHub's provided public key."""
+
+    key = public.PublicKey(public_key, encoding.Base64Encoder())
+    sealed_box = public.SealedBox(key)
+    encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
+    return base64.b64encode(encrypted).decode("utf-8")
+
+
+def put_repo_secret(token: str, encrypted_value: str, key_id: str) -> None:
+    """Create or update the GH_PAT secret on the repository."""
+
+    url = f"{GITHUB_API_BASE}/repos/{REPO}/actions/secrets/{SECRET_NAME}"
+    payload = {"encrypted_value": encrypted_value, "key_id": key_id}
+    response = requests.put(
+        url,
+        headers=authorization_headers(token),
+        json=payload,
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+
+
+def dispatch_workflow(token: str) -> None:
+    """Dispatch the auto-mossy workflow on the main branch."""
+
+    url = (
+        f"{GITHUB_API_BASE}/repos/{REPO}/actions/workflows/auto-mossy.yml/dispatches"
+    )
+    payload = {"ref": "main"}
+    response = requests.post(
+        url,
+        headers=authorization_headers(token),
+        json=payload,
+        timeout=REQUEST_TIMEOUT,
+    )
+    response.raise_for_status()
+
+
+def handle_http_error(error: requests.exceptions.HTTPError) -> None:
+    """Print a clear HTTP error message."""
+
+    response = error.response
+    if response is not None:
+        try:
+            message = response.json()
+        except ValueError:
+            message = response.text
+        print(f"HTTP error {response.status_code}: {message}")
+    else:
+        print(f"HTTP error: {error}")
+
+
+def main() -> None:
+    pat = getpass("Paste your NEW GitHub PAT (ghp_…): ").strip()
+    if not pat:
+        print("No PAT provided.")
+        sys.exit(1)
+
+    otp_code = input("Paste the 8-digit verification code GitHub emailed you: ").strip()
+    if not otp_code:
+        print("No verification code provided.")
+        sys.exit(1)
+
+    masked_token = mask_pat(pat)
+
+    try:
+        finish_pat_authorization(pat, otp_code)
+        public_key, key_id = get_repo_public_key(pat)
+        encrypted_pat = encrypt_secret(pat, public_key)
+        put_repo_secret(pat, encrypted_pat, key_id)
+        dispatch_workflow(pat)
+    except requests.exceptions.HTTPError as http_error:
+        handle_http_error(http_error)
+        print(f"Operation failed while using token {masked_token}")
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001 - provide clear CLI feedback
+        print(f"Unexpected error: {exc}")
+        print(f"Operation failed while using token {masked_token}")
+        sys.exit(1)
+
+    print("✅ PAT secret updated")
+    print("✅ Workflow dispatched (check GitHub Actions tab)")
+
+
+if __name__ == "__main__":
+    main()

--- a/finish_render_setup.py
+++ b/finish_render_setup.py
@@ -1,0 +1,266 @@
+import json
+import os
+import sys
+import time
+from typing import Dict, Iterable, List, Optional
+
+import requests
+
+RENDER_API_BASE = "https://api.render.com/v1"
+SERVICES_ENDPOINT = f"{RENDER_API_BASE}/services"
+SERVICE_DETAIL_ENDPOINT = f"{RENDER_API_BASE}/services/{{service_id}}"
+GITHUB_DISPATCH_URL = (
+    "https://api.github.com/repos/lukeblanc/mossy-4x-render/actions/workflows/auto-mossy.yml/dispatches"
+)
+POLL_INTERVAL_SECONDS = 20
+WAIT_TIMEOUT_SECONDS = 30 * 60
+
+
+def mask_token(value: str) -> str:
+    if not value:
+        return ""
+    if len(value) <= 6:
+        return "*" * len(value)
+    return f"{value[:6]}..."
+
+
+def sanitize(message: str, replacements: Dict[str, str]) -> str:
+    sanitized = message
+    for secret, masked in replacements.items():
+        if secret:
+            sanitized = sanitized.replace(secret, masked)
+    return sanitized
+
+
+def require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise ValueError(f"Missing required environment variable: {name}")
+    return value
+
+
+def create_service(
+    session: requests.Session,
+    payload: Dict[str, object],
+    replacements: Dict[str, str],
+) -> str:
+    response = session.post(SERVICES_ENDPOINT, json=payload, timeout=30)
+    if response.status_code == 409:
+        existing_id = find_service_id(session, payload.get("name"))
+        if existing_id:
+            return existing_id
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        print_http_error("Render service creation failed", response, replacements)
+        raise exc
+    data = response.json()
+    if isinstance(data, dict):
+        service_id = data.get("id") or (
+            isinstance(data.get("service"), dict) and data["service"].get("id")
+        )
+        if isinstance(service_id, str):
+            return service_id
+    raise RuntimeError(
+        sanitize(
+            f"Render service creation returned unexpected payload: {response.text}",
+            replacements,
+        )
+    )
+
+
+def find_service_id(session: requests.Session, name: Optional[object]) -> Optional[str]:
+    if not isinstance(name, str):
+        return None
+    response = session.get(SERVICES_ENDPOINT, timeout=30)
+    if response.status_code >= 400:
+        return None
+    try:
+        services: Iterable[object] = response.json()
+    except ValueError:
+        return None
+    for entry in services:
+        if not isinstance(entry, dict):
+            continue
+        entry_name = entry.get("name")
+        if entry_name == name:
+            service_id = entry.get("id")
+            if isinstance(service_id, str):
+                return service_id
+    return None
+
+
+def fetch_service_status(session: requests.Session, service_id: str) -> str:
+    response = session.get(
+        SERVICE_DETAIL_ENDPOINT.format(service_id=service_id), timeout=30
+    )
+    response.raise_for_status()
+    data = response.json()
+    if isinstance(data, dict):
+        if "service" in data and isinstance(data["service"], dict):
+            return str(data["service"].get("serviceStatus") or data["service"].get("status") or "")
+        status = data.get("serviceStatus") or data.get("status")
+        if isinstance(status, str):
+            return status
+    return ""
+
+
+def wait_for_services(
+    session: requests.Session,
+    services: Dict[str, str],
+    replacements: Dict[str, str],
+) -> None:
+    start = time.monotonic()
+    while True:
+        statuses: Dict[str, str] = {}
+        for name, service_id in services.items():
+            status = fetch_service_status(session, service_id)
+            statuses[name] = status
+        if all(status.lower() == "live" for status in statuses.values() if status):
+            return
+        if time.monotonic() - start > WAIT_TIMEOUT_SECONDS:
+            status_line = ", ".join(f"{name}={status or 'unknown'}" for name, status in statuses.items())
+            raise TimeoutError(
+                sanitize(
+                    f"Timed out waiting for services to become live: {status_line}",
+                    replacements,
+                )
+            )
+        status_line = ", ".join(f"{name}={status or 'unknown'}" for name, status in statuses.items())
+        print(sanitize(f"Waiting for services: {status_line}", replacements))
+        time.sleep(POLL_INTERVAL_SECONDS)
+
+
+def dispatch_workflow(gh_pat: str, replacements: Dict[str, str]) -> None:
+    response = requests.post(
+        GITHUB_DISPATCH_URL,
+        headers={
+            "Authorization": f"Bearer {gh_pat}",
+            "Accept": "application/vnd.github+json",
+        },
+        json={"ref": "main"},
+        timeout=30,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        print_http_error("GitHub workflow dispatch failed", response, replacements)
+        raise exc
+
+
+def print_http_error(prefix: str, response: requests.Response, replacements: Dict[str, str]) -> None:
+    try:
+        detail_obj = response.json()
+        detail = json.dumps(detail_obj, indent=2)
+    except ValueError:
+        detail = response.text
+    message = f"{prefix}: HTTP {response.status_code} - {detail}"
+    print(sanitize(message, replacements))
+
+
+def main() -> None:
+    try:
+        render_api_token = require_env("RENDER_API_TOKEN")
+        mcp_api_key = require_env("MCP_API_KEY")
+        gh_pat = require_env("GH_PAT")
+        render_deploy_hook_url = require_env("RENDER_DEPLOY_HOOK_URL")
+    except ValueError as exc:
+        print(exc)
+        sys.exit(1)
+
+    replacements = {
+        render_api_token: mask_token(render_api_token),
+        mcp_api_key: mask_token(mcp_api_key),
+        gh_pat: mask_token(gh_pat),
+        render_deploy_hook_url: mask_token(render_deploy_hook_url),
+    }
+
+    session = requests.Session()
+    session.headers.update(
+        {
+            "Authorization": f"Bearer {render_api_token}",
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+        }
+    )
+
+    shared_env_vars: List[Dict[str, str]] = [
+        {"key": "MCP_API_KEY", "value": mcp_api_key},
+        {"key": "GH_PAT", "value": gh_pat},
+        {"key": "RENDER_DEPLOY_HOOK_URL", "value": render_deploy_hook_url},
+    ]
+
+    web_payload = {
+        "type": "web_service",
+        "name": "mcp-web",
+        "plan": "free",
+        "runtime": "docker",
+        "repo": {
+            "type": "github",
+            "owner": "lukeblanc",
+            "name": "mossy-4x-render",
+            "branch": "main",
+            "path": "mcp",
+        },
+        "envVars": shared_env_vars,
+        "autoDeploy": True,
+    }
+
+    worker_payload = {
+        "type": "background_worker",
+        "name": "mcp-optimiser",
+        "plan": "starter",
+        "runtime": "docker",
+        "repo": {
+            "type": "github",
+            "owner": "lukeblanc",
+            "name": "mossy-4x-render",
+            "branch": "main",
+            "path": "mcp",
+        },
+        "envVars": shared_env_vars,
+        "serviceDetails": {
+            "startCommand": "python optimiser.py && python patcher.py",
+            "schedule": "0 1 * * *",
+        },
+        "autoDeploy": True,
+    }
+
+    try:
+        web_id = create_service(session, web_payload, replacements)
+        worker_id = create_service(session, worker_payload, replacements)
+    except requests.RequestException:
+        sys.exit(1)
+    except RuntimeError as exc:
+        print(exc)
+        sys.exit(1)
+
+    services = {"mcp-web": web_id, "mcp-optimiser": worker_id}
+
+    try:
+        wait_for_services(session, services, replacements)
+    except TimeoutError as exc:
+        print(exc)
+        sys.exit(1)
+    except requests.HTTPError as exc:
+        response = exc.response
+        if response is not None:
+            print_http_error("Failed to fetch Render service status", response, replacements)
+        else:
+            print(sanitize(f"Failed to fetch Render service status: {exc}", replacements))
+        sys.exit(1)
+    except requests.RequestException as exc:
+        print(sanitize(f"Error while polling Render services: {exc}", replacements))
+        sys.exit(1)
+
+    try:
+        dispatch_workflow(gh_pat, replacements)
+    except requests.RequestException:
+        sys.exit(1)
+
+    print("✅ Render services live")
+    print("✅ GitHub workflow dispatched")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a manually triggered workflow that runs finish_render_setup.py with the required secrets
- install Python 3.11 and dependencies before executing the setup script and emitting success or failure messaging

## Testing
- not run (workflow configuration)


------
https://chatgpt.com/codex/tasks/task_e_68fa48b8b2d483299725c4d3c1fdd23e