### PR TITLE
Switch worker to src risk-managed engine

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -15,11 +17,16 @@ class Settings(BaseSettings):
     OANDA_API_KEY: str = Field(
         "",
         description="OANDA API key used for authenticated requests.",
+        validation_alias=AliasChoices("OANDA_API_KEY", "OANDA_API_TOKEN"),
     )
     OANDA_ACCOUNT_ID: str = Field(
         "",
         description="OANDA account identifier.",
         validation_alias=AliasChoices("OANDA_ACCOUNT_ID", "ACCOUNT_ID"),
+    )
+    OANDA_ENV: str = Field(
+        "practice",
+        description="Target OANDA environment: practice or live.",
     )
     BASE_URL: str = Field(
         "https://api-fxpractice.oanda.com/v3",
@@ -136,4 +143,3 @@ class Settings(BaseSettings):
     MAX_RISK_PER_TRADE: float = float(os.getenv("MAX_RISK_PER_TRADE", "0.02"))
 
 settings = Settings()
-

--- a/render.yaml
+++ b/render.yaml
@@ -5,10 +5,12 @@ services:
     plan: starter
     autoDeploy: true
     buildCommand: "pip install -r requirements.txt"
-    startCommand: "python -m app.main"
+    startCommand: "python -m src.main"
     envVars:
       - key: MODE
         value: demo
+      - key: OANDA_ENV
+        value: practice
       - key: TZ
         value: Australia/Perth
       - key: HEARTBEAT_SECONDS
@@ -17,6 +19,8 @@ services:
         value: "60"
       - key: OANDA_API_KEY
         sync: false
+      - key: INSTRUMENTS
+        value: "EUR_USD"
       - key: OANDA_ACCOUNT_ID
         sync: false
 # ---------- MCP SERVICES ----------

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -147,7 +147,12 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                 return 0.0
             return atr * 1.5
 
-        def register_entry(self, now_utc):
+        def tp_distance_from_atr(self, atr):
+            if atr is None:
+                return 0.0
+            return atr * 3.0
+
+        def register_entry(self, now_utc, instrument: str):
             self.entries.append(now_utc)
 
         def register_exit(self, realized_pl: float) -> None:
@@ -185,6 +190,8 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
             units: int,
             *,
             sl_distance: float | None = None,
+            tp_distance: float | None = None,
+            entry_price: float | None = None,
         ) -> Dict[str, str]:
             self.calls.append(
                 {
@@ -192,6 +199,8 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                     "signal": signal,
                     "units": units,
                     "sl_distance": sl_distance,
+                    "tp_distance": tp_distance,
+                    "entry_price": entry_price,
                 }
             )
             return {"status": "SENT"}
@@ -233,6 +242,8 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                 "signal": "BUY",
                 "units": 100,
                 "sl_distance": expected_sl,
+                "tp_distance": dummy_risk.tp_distance_from_atr(0.01),
+                "entry_price": 1.2345,
             }
         ]
         assert dummy_risk.entries

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -73,7 +73,7 @@ def test_cooldown_and_spread_limits(state_dir):
         mode="paper",
     )
     now = _utc(2024, 1, 1, 2, 0)
-    manager.register_entry(now)
+    manager.register_entry(now, "EUR_USD")
 
     ok, reason = manager.should_open(now + timedelta(minutes=30), 10_000.0, [], "EUR_USD", 0.5)
     assert ok is False


### PR DESCRIPTION
## Summary
- point the Render worker to the risk-managed src engine and enforce demo-only startup guard
- add persistent, timeframe-aware cooldown/risk state with ATR-based SL/TP sizing and loss caps
- ensure broker orders include both SL/TP distances and update configuration/environment wiring for practice mode
- fix take-profit orders to send an absolute price (per OANDA spec) while keeping stop-loss distance-based

## Testing
- pytest --maxfail=1 --disable-warnings -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694904ca80f083298cbe0a982451b96d)