### PR TITLE
Fix TP pricing and demo trailing logic

### DIFF
--- a/app/broker.py
+++ b/app/broker.py
@@ -65,6 +65,7 @@ class Broker:
         *,
         sl_distance: float | None = None,
         tp_distance: float | None = None,
+        entry_price: float | None = None,
     ) -> dict:
         side = signal.upper()
         if side not in ("BUY", "SELL"):
@@ -97,11 +98,26 @@ class Broker:
                 "timeInForce": "GTC",
                 "distance": f"{sl_distance:.5f}",
             }
-        if tp_distance is not None and tp_distance > 0:
-            order_payload["takeProfitOnFill"] = {
-                "timeInForce": "GTC",
-                "distance": f"{tp_distance:.5f}",
-            }
+        if (
+            entry_price is not None
+            and tp_distance is not None
+            and tp_distance > 0
+        ):
+            try:
+                entry_val = float(entry_price)
+                tp_val = float(tp_distance)
+            except (TypeError, ValueError):
+                entry_val = None
+                tp_val = None
+            if entry_val is not None and tp_val is not None:
+                if side == "BUY":
+                    tp_price = entry_val + tp_val
+                else:
+                    tp_price = entry_val - tp_val
+                order_payload["takeProfitOnFill"] = {
+                    "timeInForce": "GTC",
+                    "price": f"{tp_price:.5f}",
+                }
 
         payload = {"order": order_payload}
 

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.broker import Broker
+from app.config import settings
+
+
+class DummyResponse:
+    status_code = 201
+
+    @staticmethod
+    def json():
+        return {"orderCreateTransaction": {"id": "1"}}
+
+
+class DummyClient:
+    def __init__(self, recorder):
+        self.recorder = recorder
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, path: str, json):
+        self.recorder["path"] = path
+        self.recorder["payload"] = json
+        return DummyResponse()
+
+
+def _configure_settings(monkeypatch):
+    monkeypatch.setattr(settings, "OANDA_API_KEY", "token")
+    monkeypatch.setattr(settings, "OANDA_ACCOUNT_ID", "acct-123")
+    monkeypatch.setattr(settings, "OANDA_ENV", "practice")
+    monkeypatch.setattr(settings, "MODE", "demo")
+
+
+def test_place_order_uses_absolute_tp_price_for_buy(monkeypatch):
+    _configure_settings(monkeypatch)
+    recorded = {}
+    monkeypatch.setattr(Broker, "_client", lambda self: DummyClient(recorded))
+
+    broker = Broker()
+    result = broker.place_order(
+        "EUR_USD",
+        "BUY",
+        1000,
+        sl_distance=0.00123,
+        tp_distance=0.005,
+        entry_price=1.2000,
+    )
+
+    assert result["status"] == "SENT"
+    order = recorded["payload"]["order"]
+    assert order["units"] == "1000"
+    assert order["stopLossOnFill"]["distance"] == "0.00123"
+    assert order["takeProfitOnFill"]["price"] == "1.20500"
+    assert "distance" not in order["takeProfitOnFill"]
+
+
+def test_place_order_uses_absolute_tp_price_for_sell(monkeypatch):
+    _configure_settings(monkeypatch)
+    recorded = {}
+    monkeypatch.setattr(Broker, "_client", lambda self: DummyClient(recorded))
+
+    broker = Broker()
+    result = broker.place_order(
+        "EUR_USD",
+        "SELL",
+        500,
+        sl_distance=0.00100,
+        tp_distance=0.005,
+        entry_price=1.2000,
+    )
+
+    assert result["status"] == "SENT"
+    order = recorded["payload"]["order"]
+    assert order["units"] == "-500"
+    assert order["stopLossOnFill"]["distance"] == "0.00100"
+    assert order["takeProfitOnFill"]["price"] == "1.19500"
+    assert "distance" not in order["takeProfitOnFill"]

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -191,6 +191,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
             *,
             sl_distance: float | None = None,
             tp_distance: float | None = None,
+            entry_price: float | None = None,
         ) -> Dict[str, str]:
             self.calls.append(
                 {
@@ -199,6 +200,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                     "units": units,
                     "sl_distance": sl_distance,
                     "tp_distance": tp_distance,
+                    "entry_price": entry_price,
                 }
             )
             return {"status": "SENT"}
@@ -241,6 +243,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                 "units": 100,
                 "sl_distance": expected_sl,
                 "tp_distance": dummy_risk.tp_distance_from_atr(0.01),
+                "entry_price": 1.2345,
             }
         ]
         assert dummy_risk.entries

--- a/tests/test_profit_protection.py
+++ b/tests/test_profit_protection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from src.profit_protection import ProfitProtection
+from src import main as main_mod
 
 
 class DummyBroker:
@@ -53,3 +54,18 @@ def test_state_clears_when_positions_exit():
     # No open trades -> cleanup should remove the high-water mark
     guard.process_open_trades([])
     assert guard.snapshot() == {}
+
+
+def test_demo_trailing_thresholds():
+    broker = DummyBroker({})
+
+    demo_guard = main_mod._profit_guard_for_mode("demo", broker)
+    live_guard = main_mod._profit_guard_for_mode("live", broker)
+    paper_guard = main_mod._profit_guard_for_mode("paper", broker)
+
+    assert demo_guard.trigger == pytest.approx(1.0)
+    assert demo_guard.trail == pytest.approx(0.5)
+    assert live_guard.trigger == pytest.approx(3.0)
+    assert live_guard.trail == pytest.approx(0.5)
+    assert paper_guard.trigger == pytest.approx(3.0)
+    assert paper_guard.trail == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- send OANDA take-profit orders using absolute price derived from entry while keeping stop-loss as distance
- apply demo-only trailing protection thresholds ($1 trigger, $0.50 trail) without changing live behaviour
- propagate entry price through the risk-managed engine and add coverage for TP pricing and trailing config

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fe24a5bd4832991a7e1bc8fb6d334)