### PR TITLE
Fix TP pricing, demo trailing logic, and add demo profit/loss caps

### DIFF
--- a/app/broker.py
+++ b/app/broker.py
@@ -65,6 +65,7 @@ class Broker:
         *,
         sl_distance: float | None = None,
         tp_distance: float | None = None,
+        entry_price: float | None = None,
     ) -> dict:
         side = signal.upper()
         if side not in ("BUY", "SELL"):
@@ -97,11 +98,26 @@ class Broker:
                 "timeInForce": "GTC",
                 "distance": f"{sl_distance:.5f}",
             }
-        if tp_distance is not None and tp_distance > 0:
-            order_payload["takeProfitOnFill"] = {
-                "timeInForce": "GTC",
-                "distance": f"{tp_distance:.5f}",
-            }
+        if (
+            entry_price is not None
+            and tp_distance is not None
+            and tp_distance > 0
+        ):
+            try:
+                entry_val = float(entry_price)
+                tp_val = float(tp_distance)
+            except (TypeError, ValueError):
+                entry_val = None
+                tp_val = None
+            if entry_val is not None and tp_val is not None:
+                if side == "BUY":
+                    tp_price = entry_val + tp_val
+                else:
+                    tp_price = entry_val - tp_val
+                order_payload["takeProfitOnFill"] = {
+                    "timeInForce": "GTC",
+                    "price": f"{tp_price:.5f}",
+                }
 
         payload = {"order": order_payload}
 

--- a/src/main.py
+++ b/src/main.py
@@ -79,6 +79,8 @@ risk_config.setdefault("cooldown_candles", int(os.getenv("COOLDOWN_CANDLES", ris
 risk_config.setdefault("max_concurrent_positions", int(os.getenv("MAX_CONCURRENT_POSITIONS", risk_config.get("max_concurrent_positions", 2))))
 risk_config.setdefault("daily_loss_cap_pct", float(os.getenv("DAILY_LOSS_CAP_PCT", risk_config.get("daily_loss_cap_pct", 0.02))))
 risk_config.setdefault("max_drawdown_cap_pct", float(os.getenv("MAX_DRAWDOWN_CAP_PCT", risk_config.get("max_drawdown_cap_pct", 0.10))))
+risk_config.setdefault("daily_profit_target_usd", float(os.getenv("DAILY_PROFIT_TARGET_USD", risk_config.get("daily_profit_target_usd", 5.0))))
+risk_config.setdefault("daily_loss_stop_usd", float(os.getenv("DAILY_LOSS_STOP_USD", risk_config.get("daily_loss_stop_usd", 2.0))))
 risk_config["timeframe"] = config["timeframe"]
 config["risk"] = risk_config
 
@@ -90,8 +92,22 @@ if oanda_env == "live" or config["mode"] == "live":
 
 broker = Broker()
 engine = DecisionEngine(config)
-risk = RiskManager(config.get("risk", {}), mode=config["mode"], state_dir=DATA_DIR)
-profit_guard = ProfitProtection(broker)
+risk = RiskManager(
+    config.get("risk", {}),
+    mode=config["mode"],
+    state_dir=DATA_DIR,
+    demo_mode=(mode_env == "demo"),
+)
+
+
+def _profit_guard_for_mode(mode: str, broker: Broker) -> ProfitProtection:
+    label = (mode or "").lower()
+    if label == "demo":
+        return ProfitProtection(broker, trigger=1.0, trail=0.5)
+    return ProfitProtection(broker)
+
+
+profit_guard = _profit_guard_for_mode(mode_env, broker)
 
 
 def _startup_checks() -> None:
@@ -232,6 +248,7 @@ async def decision_cycle() -> None:
                 units,
                 sl_distance=sl_distance,
                 tp_distance=tp_distance,
+                entry_price=entry_price,
             )
             if result.get("status") == "SENT":
                 engine.mark_trade(evaluation.instrument)

--- a/src/risk_manager.py
+++ b/src/risk_manager.py
@@ -50,7 +50,9 @@ def _sanitize_equity(equity: Optional[float]) -> Optional[float]:
 class RiskState:
     day_id: Optional[str] = None
     week_id: Optional[str] = None
+    day_id_utc: Optional[str] = None
     day_start_equity: Optional[float] = None
+    day_start_equity_utc: Optional[float] = None
     week_start_equity: Optional[float] = None
     daily_realized_pl: float = 0.0
     weekly_realized_pl: float = 0.0
@@ -62,12 +64,16 @@ class RiskState:
     has_hit_weekly_target: bool = False
     live_halted_on_equity_floor: bool = False
     max_drawdown_halt: bool = False
+    daily_profit_cap_hit: bool = False
+    daily_loss_stop_hit: bool = False
 
     def to_dict(self) -> Dict:
         return {
             "day_id": self.day_id,
             "week_id": self.week_id,
+            "day_id_utc": self.day_id_utc,
             "day_start_equity": self.day_start_equity,
+            "day_start_equity_utc": self.day_start_equity_utc,
             "week_start_equity": self.week_start_equity,
             "daily_realized_pl": self.daily_realized_pl,
             "weekly_realized_pl": self.weekly_realized_pl,
@@ -79,6 +85,8 @@ class RiskState:
             "has_hit_weekly_target": self.has_hit_weekly_target,
             "live_halted_on_equity_floor": self.live_halted_on_equity_floor,
             "max_drawdown_halt": self.max_drawdown_halt,
+            "daily_profit_cap_hit": self.daily_profit_cap_hit,
+            "daily_loss_stop_hit": self.daily_loss_stop_hit,
         }
 
     @classmethod
@@ -86,7 +94,9 @@ class RiskState:
         return cls(
             day_id=data.get("day_id"),
             week_id=data.get("week_id"),
+            day_id_utc=data.get("day_id_utc"),
             day_start_equity=data.get("day_start_equity"),
+            day_start_equity_utc=data.get("day_start_equity_utc"),
             week_start_equity=data.get("week_start_equity"),
             daily_realized_pl=float(data.get("daily_realized_pl", 0.0)),
             weekly_realized_pl=float(data.get("weekly_realized_pl", 0.0)),
@@ -100,6 +110,8 @@ class RiskState:
                 data.get("live_halted_on_equity_floor", False)
             ),
             max_drawdown_halt=bool(data.get("max_drawdown_halt", False)),
+            daily_profit_cap_hit=bool(data.get("daily_profit_cap_hit", False)),
+            daily_loss_stop_hit=bool(data.get("daily_loss_stop_hit", False)),
         )
 
 
@@ -119,9 +131,11 @@ class RiskManager:
     mode: str = "paper"
     state: RiskState = field(default_factory=RiskState)
     state_dir: Optional[Path] = None
+    demo_mode: bool = False
 
     def __post_init__(self) -> None:
         self.mode = (self.mode or "paper").lower()
+        self.demo_mode = bool(self.demo_mode)
         if self.state_dir:
             self.state_dir.mkdir(parents=True, exist_ok=True)
             self._state_file = (self.state_dir / "risk_state.json").resolve()
@@ -147,6 +161,12 @@ class RiskManager:
         self.cooldown_candles = int(self.config.get("cooldown_candles", 9))
         self.daily_loss_cap_pct = float(
             self.config.get("daily_loss_cap_pct", 0.02)
+        )
+        self.daily_profit_target_usd = float(
+            self.config.get("daily_profit_target_usd", 5.0)
+        )
+        self.daily_loss_stop_usd = float(
+            self.config.get("daily_loss_stop_usd", 2.0)
         )
         self.weekly_loss_cap_pct = float(
             self.config.get("weekly_loss_cap_pct", 0.03)
@@ -257,11 +277,20 @@ class RiskManager:
                 if not self.allow_trading_above_target:
                     return False, "weekly-target-reached"
 
-        if self._breached_daily_loss(equity):
-            return False, "daily-loss-cap"
+        if self.demo_mode:
+            if self._breached_daily_loss_stop(equity):
+                print("[LOSS-CAP] Daily loss limit reached. Blocking new entries until next UTC day.", flush=True)
+                return False, "daily-loss-stop"
+        else:
+            if self._breached_daily_loss(equity):
+                return False, "daily-loss-cap"
 
         if self._breached_weekly_loss(equity):
             return False, "weekly-loss-cap"
+
+        if self._breached_daily_profit_cap(equity):
+            print("[PROFIT-CAP] New entries blocked due to daily profit cap", flush=True)
+            return False, "daily-profit-cap"
 
         if self.state.max_drawdown_halt:
             return False, "max-drawdown"
@@ -314,8 +343,39 @@ class RiskManager:
         day_id = awst_now.strftime("%Y-%m-%d")
         iso_cal = awst_now.isocalendar()
         week_id = f"{iso_cal.year}-W{iso_cal.week:02d}"
+        utc_day_id = now_utc.strftime("%Y-%m-%d")
         changed = False
         valid_equity = _sanitize_equity(equity)
+
+        # Track UTC day start equity for demo profit cap
+        if valid_equity is None:
+            if self.state.day_id_utc != utc_day_id:
+                self.state.day_id_utc = utc_day_id
+                self.state.day_start_equity_utc = None
+                self.state.daily_profit_cap_hit = False
+                self.state.daily_loss_stop_hit = False
+                print("[LOSS-CAP] Daily loss stop reset for new UTC day", flush=True)
+                changed = True
+        else:
+            if self.state.day_id_utc != utc_day_id:
+                self.state.day_id_utc = utc_day_id
+                self.state.day_start_equity_utc = valid_equity
+                self.state.daily_profit_cap_hit = False
+                self.state.daily_loss_stop_hit = False
+                print(
+                    f"[PROFIT-CAP] UTC day start equity set to {valid_equity:.2f}",
+                    flush=True,
+                )
+                print("[LOSS-CAP] Daily loss stop reset for new UTC day", flush=True)
+                changed = True
+            elif self.state.day_start_equity_utc is None:
+                self.state.day_start_equity_utc = valid_equity
+                print(
+                    f"[PROFIT-CAP] UTC day start equity set to {valid_equity:.2f}",
+                    flush=True,
+                )
+                print("[LOSS-CAP] Daily loss stop reset for new UTC day", flush=True)
+                changed = True
 
         if valid_equity is None:
             if self.state.day_id != day_id:
@@ -371,6 +431,35 @@ class RiskManager:
         drawdown = self.state.day_start_equity - equity
         return drawdown >= self.state.day_start_equity * self.daily_loss_cap_pct
 
+    def _breached_daily_loss_stop(self, equity: float) -> bool:
+        if not self.demo_mode:
+            return False
+        if self.daily_loss_stop_usd <= 0 and self.daily_loss_cap_pct <= 0:
+            return False
+        if self.state.day_start_equity_utc is None:
+            return False
+        valid_equity = _sanitize_equity(equity)
+        if valid_equity is None:
+            return False
+        if self.state.daily_loss_stop_hit:
+            return True
+
+        usd_trigger = False
+        if self.daily_loss_stop_usd > 0:
+            usd_trigger = valid_equity <= self.state.day_start_equity_utc - self.daily_loss_stop_usd
+
+        pct_trigger = False
+        if self.daily_loss_cap_pct > 0 and self.state.day_start_equity is not None:
+            drawdown = self.state.day_start_equity - valid_equity
+            pct_trigger = drawdown >= self.state.day_start_equity * self.daily_loss_cap_pct
+
+        if usd_trigger or pct_trigger:
+            self.state.daily_loss_stop_hit = True
+            self._save_state()
+            return True
+
+        return False
+
     def _breached_weekly_loss(self, equity: float) -> bool:
         if self.weekly_loss_cap_pct <= 0:
             return False
@@ -378,6 +467,29 @@ class RiskManager:
             return False
         drawdown = self.state.week_start_equity - equity
         return drawdown >= self.state.week_start_equity * self.weekly_loss_cap_pct
+
+    def _breached_daily_profit_cap(self, equity: float) -> bool:
+        if not self.demo_mode:
+            return False
+        if self.daily_profit_target_usd <= 0:
+            return False
+        if self.state.day_start_equity_utc is None:
+            return False
+        valid_equity = _sanitize_equity(equity)
+        if valid_equity is None:
+            return False
+        if self.state.daily_profit_cap_hit:
+            return True
+        profit = valid_equity - self.state.day_start_equity_utc
+        if profit >= self.daily_profit_target_usd:
+            self.state.daily_profit_cap_hit = True
+            print(
+                f"[PROFIT-CAP] Daily profit target hit ({profit:.2f} >= {self.daily_profit_target_usd:.2f}); blocking new entries",
+                flush=True,
+            )
+            self._save_state()
+            return True
+        return False
 
     def _breached_max_drawdown(self, equity: float) -> bool:
         if self.max_drawdown_cap_pct <= 0:

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.broker import Broker
+from app.config import settings
+
+
+class DummyResponse:
+    status_code = 201
+
+    @staticmethod
+    def json():
+        return {"orderCreateTransaction": {"id": "1"}}
+
+
+class DummyClient:
+    def __init__(self, recorder):
+        self.recorder = recorder
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, path: str, json):
+        self.recorder["path"] = path
+        self.recorder["payload"] = json
+        return DummyResponse()
+
+
+def _configure_settings(monkeypatch):
+    monkeypatch.setattr(settings, "OANDA_API_KEY", "token")
+    monkeypatch.setattr(settings, "OANDA_ACCOUNT_ID", "acct-123")
+    monkeypatch.setattr(settings, "OANDA_ENV", "practice")
+    monkeypatch.setattr(settings, "MODE", "demo")
+
+
+def test_place_order_uses_absolute_tp_price_for_buy(monkeypatch):
+    _configure_settings(monkeypatch)
+    recorded = {}
+    monkeypatch.setattr(Broker, "_client", lambda self: DummyClient(recorded))
+
+    broker = Broker()
+    result = broker.place_order(
+        "EUR_USD",
+        "BUY",
+        1000,
+        sl_distance=0.00123,
+        tp_distance=0.005,
+        entry_price=1.2000,
+    )
+
+    assert result["status"] == "SENT"
+    order = recorded["payload"]["order"]
+    assert order["units"] == "1000"
+    assert order["stopLossOnFill"]["distance"] == "0.00123"
+    assert order["takeProfitOnFill"]["price"] == "1.20500"
+    assert "distance" not in order["takeProfitOnFill"]
+
+
+def test_place_order_uses_absolute_tp_price_for_sell(monkeypatch):
+    _configure_settings(monkeypatch)
+    recorded = {}
+    monkeypatch.setattr(Broker, "_client", lambda self: DummyClient(recorded))
+
+    broker = Broker()
+    result = broker.place_order(
+        "EUR_USD",
+        "SELL",
+        500,
+        sl_distance=0.00100,
+        tp_distance=0.005,
+        entry_price=1.2000,
+    )
+
+    assert result["status"] == "SENT"
+    order = recorded["payload"]["order"]
+    assert order["units"] == "-500"
+    assert order["stopLossOnFill"]["distance"] == "0.00100"
+    assert order["takeProfitOnFill"]["price"] == "1.19500"
+    assert "distance" not in order["takeProfitOnFill"]

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -191,6 +191,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
             *,
             sl_distance: float | None = None,
             tp_distance: float | None = None,
+            entry_price: float | None = None,
         ) -> Dict[str, str]:
             self.calls.append(
                 {
@@ -199,6 +200,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                     "units": units,
                     "sl_distance": sl_distance,
                     "tp_distance": tp_distance,
+                    "entry_price": entry_price,
                 }
             )
             return {"status": "SENT"}
@@ -241,6 +243,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                 "units": 100,
                 "sl_distance": expected_sl,
                 "tp_distance": dummy_risk.tp_distance_from_atr(0.01),
+                "entry_price": 1.2345,
             }
         ]
         assert dummy_risk.entries

--- a/tests/test_profit_protection.py
+++ b/tests/test_profit_protection.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from src.profit_protection import ProfitProtection
+from src import main as main_mod
 
 
 class DummyBroker:
@@ -53,3 +54,18 @@ def test_state_clears_when_positions_exit():
     # No open trades -> cleanup should remove the high-water mark
     guard.process_open_trades([])
     assert guard.snapshot() == {}
+
+
+def test_demo_trailing_thresholds():
+    broker = DummyBroker({})
+
+    demo_guard = main_mod._profit_guard_for_mode("demo", broker)
+    live_guard = main_mod._profit_guard_for_mode("live", broker)
+    paper_guard = main_mod._profit_guard_for_mode("paper", broker)
+
+    assert demo_guard.trigger == pytest.approx(1.0)
+    assert demo_guard.trail == pytest.approx(0.5)
+    assert live_guard.trigger == pytest.approx(3.0)
+    assert live_guard.trail == pytest.approx(0.5)
+    assert paper_guard.trigger == pytest.approx(3.0)
+    assert paper_guard.trail == pytest.approx(0.5)

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -100,6 +100,113 @@ def test_daily_loss_cap_blocks_after_drawdown(state_dir):
     assert reason == "daily-loss-cap"
 
 
+def test_demo_profit_cap_allows_until_target(state_dir, capsys):
+    manager = RiskManager(
+        {"daily_profit_target_usd": 5.0},
+        mode="paper",
+        demo_mode=True,
+    )
+    now = _utc(2024, 2, 1, 0, 0)
+
+    ok, reason = manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    assert ok is True
+    assert reason == "ok"
+    first_log = capsys.readouterr().out
+    assert "UTC day start equity set to 1000.00" in first_log
+
+    ok, reason = manager.should_open(now + timedelta(hours=1), 1_004.0, [], "EUR_USD", 0.2)
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_demo_profit_cap_blocks_and_resets_next_day(state_dir, capsys):
+    manager = RiskManager(
+        {"daily_profit_target_usd": 5.0},
+        mode="paper",
+        demo_mode=True,
+    )
+    now = _utc(2024, 2, 1, 0, 0)
+
+    manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    capsys.readouterr()
+
+    ok, reason = manager.should_open(now + timedelta(hours=1), 1_006.0, [], "EUR_USD", 0.2)
+    captured = capsys.readouterr().out
+    assert ok is False
+    assert reason == "daily-profit-cap"
+    assert "Daily profit target hit" in captured
+    assert manager.state.daily_profit_cap_hit is True
+
+    next_day = now + timedelta(days=1)
+    ok, reason = manager.should_open(next_day, 1_002.0, [], "EUR_USD", 0.2)
+    resumed = capsys.readouterr().out
+    assert ok is True
+    assert reason == "ok"
+    assert "UTC day start equity set to 1002.00" in resumed
+    assert manager.state.daily_profit_cap_hit is False
+
+
+def test_demo_loss_stop_allows_until_threshold(state_dir, capsys):
+    manager = RiskManager(
+        {"daily_loss_stop_usd": 2.0, "daily_loss_cap_pct": 0.0},
+        mode="paper",
+        demo_mode=True,
+    )
+    now = _utc(2024, 3, 1, 0, 0)
+
+    ok, reason = manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    assert ok is True
+    assert reason == "ok"
+    capsys.readouterr()
+
+    ok, reason = manager.should_open(now + timedelta(hours=1), 998.5, [], "EUR_USD", 0.2)
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_demo_loss_stop_blocks_after_hit_and_logs(state_dir, capsys):
+    manager = RiskManager(
+        {"daily_loss_stop_usd": 2.0, "daily_loss_cap_pct": 0.0},
+        mode="paper",
+        demo_mode=True,
+    )
+    now = _utc(2024, 3, 1, 0, 0)
+
+    manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    capsys.readouterr()
+
+    ok, reason = manager.should_open(now + timedelta(hours=1), 997.5, [], "EUR_USD", 0.2)
+    log_output = capsys.readouterr().out
+
+    assert ok is False
+    assert reason == "daily-loss-stop"
+    assert "[LOSS-CAP] Daily loss limit reached. Blocking new entries until next UTC day." in log_output
+    assert manager.state.daily_loss_stop_hit is True
+    assert manager.state.daily_profit_cap_hit is False
+
+
+def test_demo_loss_stop_resets_next_utc_day(state_dir, capsys):
+    manager = RiskManager(
+        {"daily_loss_stop_usd": 2.0, "daily_loss_cap_pct": 0.0},
+        mode="paper",
+        demo_mode=True,
+    )
+    now = _utc(2024, 3, 1, 0, 0)
+
+    manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    manager.should_open(now + timedelta(hours=1), 997.5, [], "EUR_USD", 0.2)
+    capsys.readouterr()
+
+    next_day = now + timedelta(days=1)
+    ok, reason = manager.should_open(next_day, 1_001.0, [], "EUR_USD", 0.2)
+    log_output = capsys.readouterr().out
+
+    assert ok is True
+    assert reason == "ok"
+    assert "[LOSS-CAP] Daily loss stop reset for new UTC day" in log_output
+    assert manager.state.daily_loss_stop_hit is False
+
+
 def test_rollover_window_blocks(state_dir):
     manager = RiskManager(
         {


### PR DESCRIPTION
## Summary
- send OANDA take-profit orders using absolute price derived from entry while keeping stop-loss as distance
- apply demo-only trailing protection thresholds ($1 trigger, $0.50 trail) without changing live behaviour
- add demo-only daily profit and loss stops that block new entries for the remainder of the UTC day once hit, automatically resetting the next day

## Testing
- pytest --maxfail=1 --disable-warnings -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694fe24a5bd4832991a7e1bc8fb6d334)