### PR TITLE
Fix malformed defaults risk configuration

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -23,30 +23,7 @@
   "max_open_trades": 1,
   "risk_per_trade": 0.08,
   "cooldown_minutes": 2,
-  "risk": {"weekly_profit_target": 400.0,
-"no_giveback_below_target": true,
-"allow_trading_above_target": true,
-"equity_floor": 1000.0,
-"risk_per_trade_pct": 0.08,
-"max_concurrent_positions": 1,
-"cooldown_minutes": 2,
-"daily_loss_cap_pct": 0.15,
-"weekly_loss_cap_pct": 0.30,
-"atr_stop_mult": 1.8,
-"atr_period": 14,
-"spread_pips_limit": {
-  "EUR_USD": 1.5,
-  "AUD_USD": 1.8,
-  "GBP_USD": 2.0,
-  "USD_JPY": 2.0,
-  "XAU_USD": 5.0
-},
-"default_spread_pips_limit": 2.5,
-"rollover_quiet_awst": {
-  "start": "04:55",
-  "end": "05:05"
-}
-
+  "risk": {
     "weekly_profit_target": 250.0,
     "no_giveback_below_target": true,
     "allow_trading_above_target": true,


### PR DESCRIPTION
## Summary
- fix the malformed risk defaults JSON by removing the duplicate inline block and reformatting the risk settings
- keep the intended risk parameters (e.g., weekly_profit_target 250, cooldown_minutes 45) in a valid structured object

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695001a9e51c8329a4b61132d6c43d7d)