### PR TITLE
Add session-based entry filter for demo entries

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from app.health import watchdog
 from src.decision_engine import DecisionEngine, Evaluation
 from src.risk_manager import RiskManager
 from src.profit_protection import ProfitProtection
+from src import session_filter
 from src import position_sizer
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "defaults.json"
@@ -220,6 +221,14 @@ async def decision_cycle() -> None:
             if not ok_to_open:
                 print(
                     f"[TRADE] Skipping {evaluation.instrument} due to {reason}",
+                    flush=True,
+                )
+                continue
+
+            if not session_filter.is_entry_session(now_utc, mode=mode_env):
+                ts = now_utc.astimezone(timezone.utc).strftime("%H:%M")
+                print(
+                    f"[SESSION] Entry blocked – outside trading session (UTC {ts})",
                     flush=True,
                 )
                 continue

--- a/src/session_filter.py
+++ b/src/session_filter.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+
+
+_LONDON_START = time(7, 0)
+_LONDON_END = time(16, 0)
+_NY_EARLY_START = time(12, 0)
+_NY_EARLY_END = time(17, 0)
+
+
+def _is_in_window(current: time, start: time, end: time) -> bool:
+    return start <= current < end
+
+
+def is_entry_session(now_utc: datetime, *, mode: str | None = None) -> bool:
+    """Return True if new entries are allowed for the given timestamp.
+
+    The filter only applies in demo mode; for all other modes entries are always
+    permitted.
+    """
+
+    if (mode or "").lower() != "demo":
+        return True
+
+    aware = now_utc.astimezone(timezone.utc)
+    current_time = aware.time()
+
+    in_london = _is_in_window(current_time, _LONDON_START, _LONDON_END)
+    in_ny = _is_in_window(current_time, _NY_EARLY_START, _NY_EARLY_END)
+    return in_london or in_ny
+
+
+__all__ = ["is_entry_session"]

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -161,8 +161,10 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
     class DummyEngine:
         def __init__(self) -> None:
             self.marked: List[str] = []
+            self.evaluations: int = 0
 
         def evaluate_all(self) -> List[Evaluation]:
+            self.evaluations += 1
             return [
                 Evaluation(
                     instrument="EUR_USD",
@@ -293,6 +295,116 @@ def test_decision_cycle_updates_watchdog_on_error(monkeypatch):
 
     try:
         assert events["error"] is True
+        assert watchdog.last_decision_ts > before
+    finally:
+        watchdog.last_decision_ts = original_ts
+
+
+def test_decision_cycle_blocks_entries_outside_session(monkeypatch, capsys):
+    class DummyRisk:
+        risk_per_trade_pct = 0.001
+
+        def __init__(self) -> None:
+            self.entries: List[datetime] = []
+
+        def enforce_equity_floor(self, *args, **kwargs):
+            pass
+
+        def should_open(self, *args, **kwargs):
+            return True, "ok"
+
+        def sl_distance_from_atr(self, atr):
+            return 0.01
+
+        def tp_distance_from_atr(self, atr):
+            return 0.02
+
+        def register_entry(self, now_utc, instrument: str):
+            self.entries.append(now_utc)
+
+        def register_exit(self, *args, **kwargs):
+            pass
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self.marked: List[str] = []
+            self.evaluations: int = 0
+
+        def evaluate_all(self) -> List[Evaluation]:
+            self.evaluations += 1
+            return [
+                Evaluation(
+                    instrument="EUR_USD",
+                    signal="BUY",
+                    diagnostics={"atr": 0.01, "close": 1.2345},
+                    reason="trend",
+                    market_active=True,
+                )
+            ]
+
+        def mark_trade(self, instrument: str) -> None:
+            self.marked.append(instrument)
+
+    class DummyBroker:
+        def __init__(self) -> None:
+            self.calls: List[Dict[str, object]] = []
+
+        def place_order(
+            self,
+            instrument: str,
+            signal: str,
+            units: int,
+            *args,
+            **kwargs,
+        ) -> Dict[str, str]:
+            self.calls.append({"instrument": instrument, "signal": signal, "units": units})
+            return {"status": "SENT"}
+
+        def account_equity(self) -> float:
+            return 10_000.0
+
+        def current_spread(self, instrument: str) -> float:
+            return 0.5
+
+        def close_all_positions(self) -> None:
+            pass
+
+    dummy_engine = DummyEngine()
+    dummy_broker = DummyBroker()
+    dummy_risk = DummyRisk()
+    calls = {"should_open": 0}
+    monkeypatch.setattr(main, "engine", dummy_engine)
+    monkeypatch.setattr(main, "broker", dummy_broker)
+    monkeypatch.setattr(main, "risk", dummy_risk)
+    monkeypatch.setattr(main, "profit_guard", type("PG", (), {"process_open_trades": lambda self, trades: []})())
+    monkeypatch.setattr(main, "_open_trades_state", lambda: [])
+    monkeypatch.setattr(
+        dummy_risk,
+        "should_open",
+        lambda *args, **kwargs: calls.__setitem__("should_open", calls["should_open"] + 1) or (True, "ok"),
+    )
+    monkeypatch.setattr(main.session_filter, "is_entry_session", lambda *args, **kwargs: False)
+    monkeypatch.setattr(main, "mode_env", "demo")
+    monkeypatch.setattr(
+        main.position_sizer,
+        "units_for_risk",
+        lambda equity, entry_price, stop_distance, risk_pct: 100,
+    )
+
+    before = datetime.now(timezone.utc) - timedelta(hours=1)
+    original_ts = watchdog.last_decision_ts
+    watchdog.last_decision_ts = before
+
+    asyncio.run(main.decision_cycle())
+
+    try:
+        captured = capsys.readouterr().out
+        assert "[SESSION] Entry blocked – outside trading session" in captured
+        assert dummy_engine.evaluations == 1
+        assert dummy_engine.marked == []
+        assert dummy_broker.calls == []
+        assert dummy_risk.entries == []
+        assert calls["should_open"] == 1
         assert watchdog.last_decision_ts > before
     finally:
         watchdog.last_decision_ts = original_ts

--- a/tests/test_session_filter.py
+++ b/tests/test_session_filter.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from src.session_filter import is_entry_session
+
+
+def _utc(hour: int, minute: int = 0) -> datetime:
+    return datetime(2024, 1, 1, hour, minute, tzinfo=timezone.utc)
+
+
+def test_entry_allowed_london_session_demo_mode():
+    assert is_entry_session(_utc(7, 30), mode="demo") is True
+
+
+def test_entry_allowed_overlap_session_demo_mode():
+    assert is_entry_session(_utc(12, 30), mode="demo") is True
+
+
+def test_entry_blocked_outside_session_demo_mode():
+    assert is_entry_session(_utc(20, 0), mode="demo") is False
+
+
+def test_session_filter_bypassed_outside_demo_mode():
+    assert is_entry_session(_utc(3, 0), mode="paper") is True
+    assert is_entry_session(_utc(3, 0), mode="live") is True


### PR DESCRIPTION
## Summary
- add a UTC session filter utility to allow entries only during London and early New York sessions in demo mode
- gate order placement in the decision cycle with clear logging while leaving scanning and management unchanged
- cover session windows and blocked entry handling with new unit tests

## Testing
- pytest --maxfail=1 --disable-warnings -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695008d3c53c8329bad1dbdf323471d8)