### PR TITLE
Add forex market projector module

### DIFF
--- a/src/decision_engine.py
+++ b/src/decision_engine.py
@@ -10,6 +10,8 @@ from typing import Callable, Dict, Iterable, List, Optional, Sequence
 
 import httpx
 
+from src.projector import project_market
+
 PRACTICE_BASE_URL = "https://api-fxpractice.oanda.com/v3"
 
 DEFAULT_INSTRUMENTS: List[str] = [
@@ -142,6 +144,7 @@ class DecisionEngine:
             )
 
         diagnostics = self._build_indicators(normalized)
+        self._log_projection(instrument, normalized, diagnostics)
         signal, reason = self._generate_signal(diagnostics)
 
         cooldown_until = self._cooldowns.get(instrument)
@@ -242,6 +245,49 @@ class DecisionEngine:
         else:
             atr_str = f"{atr:.5f}"
         print(f"[SIGNAL] {instrument} signal={signal} rsi={rsi_str} atr={atr_str}", flush=True)
+
+    def _log_projection(
+        self,
+        instrument: str,
+        candles: List[Dict[str, float]],
+        diagnostics: Dict[str, float],
+    ) -> None:
+        try:
+            projection = project_market(instrument, candles, diagnostics, self._now())
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"[PROJECTOR] {instrument} skipped error={exc}", flush=True)
+            return
+
+        enabled = self._as_bool(os.getenv("ENABLE_PROJECTOR", "false"))
+        if not enabled:
+            return
+
+        ts = projection.get("timestamp")
+        ts_str = (
+            ts.astimezone(timezone.utc).strftime("%H:%M")
+            if isinstance(ts, datetime)
+            else "n/a"
+        )
+        bias = projection.get("bias", "NEUTRAL")
+        bias_score = projection.get("bias_score", 0.0) or 0.0
+        volatility = projection.get("volatility", "NORMAL")
+        confidence = projection.get("confidence", 0.0) or 0.0
+        bias_score_fmt = f"{bias_score:.2f}"
+        confidence_fmt = f"{int(round(confidence))}"
+
+        range_info = projection.get("range") or {}
+        low = range_info.get("low")
+        high = range_info.get("high")
+        range_fmt = "n/a"
+        if isinstance(low, (int, float)) and isinstance(high, (int, float)):
+            range_fmt = f"{low:.4f}..{high:.4f}"
+
+        print(
+            f"[PROJECTOR] {instrument} ts={ts_str} bias={bias} "
+            f"score={bias_score_fmt} conf={confidence_fmt} "
+            f"vol={volatility} range={range_fmt}",
+            flush=True,
+        )
 
     def _resolve_instruments(
         self, instruments: Optional[Iterable[str]], merge_default_instruments: bool

--- a/src/projector.py
+++ b/src/projector.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import math
+import os
+from datetime import datetime
+from typing import Dict, Iterable, Mapping, Tuple
+
+
+def _clamp(value: float, lower: float, upper: float) -> float:
+    return max(lower, min(upper, value))
+
+
+def _true_ranges(candles: Iterable[Mapping[str, float]]) -> Tuple[float, ...]:
+    ranges = []
+    last_close = None
+    for candle in candles:
+        try:
+            high = float(candle["h"])
+            low = float(candle["l"])
+            close = float(candle["c"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if last_close is None:
+            last_close = close
+            continue
+        tr = max(high - low, abs(high - last_close), abs(low - last_close))
+        ranges.append(tr)
+        last_close = close
+    return tuple(ranges)
+
+
+def _atr_series(true_ranges: Tuple[float, ...], length: int) -> Tuple[float, ...]:
+    if length <= 0 or len(true_ranges) < length:
+        return tuple()
+    atr_values = []
+    for idx in range(length, len(true_ranges) + 1):
+        window = true_ranges[idx - length : idx]
+        atr_values.append(sum(window) / length)
+    return tuple(atr_values)
+
+
+def _volatility_label(current_atr: float, true_ranges: Tuple[float, ...], atr_length: int) -> str:
+    if current_atr <= 0 or math.isnan(current_atr):
+        return "NORMAL"
+    atr_values = _atr_series(true_ranges, atr_length)
+    if not atr_values:
+        return "NORMAL"
+    rolling_mean = sum(atr_values) / len(atr_values)
+    if rolling_mean <= 0 or math.isnan(rolling_mean):
+        return "NORMAL"
+    ratio = current_atr / rolling_mean
+    if ratio < 0.9:
+        return "LOW"
+    if ratio > 1.1:
+        return "HIGH"
+    return "NORMAL"
+
+
+def project_market(
+    pair: str,
+    candles: Iterable[Mapping[str, float]],
+    indicators: Mapping[str, float],
+    now_utc: datetime,
+) -> Dict[str, object]:
+    ema_fast = indicators.get("ema_fast", math.nan)
+    ema_slow = indicators.get("ema_slow", math.nan)
+    atr = indicators.get("atr", math.nan)
+    rsi = indicators.get("rsi", math.nan)
+    last_close = indicators.get("close", math.nan)
+
+    candle_buffer = tuple(candles)
+
+    atr_length = int(os.getenv("PROJECTOR_ATR_LENGTH", 14))
+
+    slope_score = 0.0
+    if all(not math.isnan(val) for val in (ema_fast, ema_slow, atr)):
+        slope_score = _clamp((ema_fast - ema_slow) / max(atr, 1e-6), -1.0, 1.0)
+
+    momentum_score = 0.0
+    if not math.isnan(rsi):
+        momentum_score = _clamp((rsi - 50.0) / 25.0, -1.0, 1.0)
+
+    bias_score = 0.6 * slope_score + 0.4 * momentum_score
+    if bias_score > 0.2:
+        bias = "BULL"
+    elif bias_score < -0.2:
+        bias = "BEAR"
+    else:
+        bias = "NEUTRAL"
+
+    try:
+        horizon_env = int(os.getenv("PROJECTOR_HORIZON", 4))
+    except ValueError:
+        horizon_env = 4
+    horizon = max(1, horizon_env)
+    if math.isnan(last_close) and candle_buffer:
+        try:
+            last_close = float(candle_buffer[-1]["c"])
+        except Exception:
+            last_close = math.nan
+
+    if math.isnan(atr):
+        range_half = 0.0
+    else:
+        range_half = atr * math.sqrt(horizon)
+    center = last_close if not math.isnan(last_close) else 0.0
+    projected_low = center - range_half
+    projected_high = center + range_half
+
+    tr_list = _true_ranges(candle_buffer)
+    volatility = _volatility_label(atr, tr_list, atr_length)
+
+    confidence = 50.0
+    confidence += 20.0 * abs(bias_score)
+    if volatility == "NORMAL":
+        confidence += 10.0
+    if volatility == "HIGH":
+        confidence -= 10.0
+    if bias == "NEUTRAL":
+        confidence -= 10.0
+    confidence = _clamp(confidence, 0.0, 100.0)
+
+    return {
+        "pair": pair,
+        "timestamp": now_utc,
+        "bias": bias,
+        "bias_score": bias_score,
+        "range": {
+            "center": center,
+            "low": projected_low,
+            "high": projected_high,
+            "horizon": horizon,
+        },
+        "volatility": volatility,
+        "confidence": confidence,
+    }
+
+
+__all__ = ["project_market"]

--- a/tests/test_projector.py
+++ b/tests/test_projector.py
@@ -1,0 +1,128 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.decision_engine import DecisionEngine  # noqa: E402
+from src.projector import project_market  # noqa: E402
+
+
+@pytest.fixture()
+def sample_candles() -> List[Dict[str, float]]:
+    return [
+        {"o": 1.10, "h": 1.105, "l": 1.095, "c": 1.10},
+        {"o": 1.11, "h": 1.115, "l": 1.105, "c": 1.11},
+        {"o": 1.12, "h": 1.125, "l": 1.115, "c": 1.12},
+        {"o": 1.13, "h": 1.135, "l": 1.125, "c": 1.13},
+        {"o": 1.14, "h": 1.145, "l": 1.135, "c": 1.14},
+    ]
+
+
+def test_project_market_generates_bullish_projection(monkeypatch, sample_candles):
+    monkeypatch.setenv("PROJECTOR_HORIZON", "4")
+    monkeypatch.setenv("PROJECTOR_ATR_LENGTH", "3")
+    indicators = {
+        "ema_fast": 1.20,
+        "ema_slow": 1.00,
+        "rsi": 70.0,
+        "atr": 0.015,
+        "close": 1.20,
+    }
+    projection = project_market(
+        "EUR_USD",
+        sample_candles,
+        indicators,
+        datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert projection["bias"] == "BULL"
+    assert pytest.approx(projection["bias_score"], rel=1e-3) == 0.92
+    assert projection["range"]["horizon"] == 4
+    assert pytest.approx(projection["range"]["low"], rel=1e-3) == 1.17
+    assert pytest.approx(projection["range"]["high"], rel=1e-3) == 1.23
+    assert projection["volatility"] == "NORMAL"
+    assert pytest.approx(projection["confidence"], rel=1e-3) == 78.4
+
+
+def test_project_market_handles_neutral_high_vol(monkeypatch, sample_candles):
+    monkeypatch.setenv("PROJECTOR_HORIZON", "2")
+    monkeypatch.setenv("PROJECTOR_ATR_LENGTH", "2")
+    indicators = {
+        "ema_fast": 1.00,
+        "ema_slow": 1.00,
+        "rsi": 50.0,
+        "atr": 0.05,
+        "close": 1.00,
+    }
+    projection = project_market(
+        "GBP_USD",
+        sample_candles,
+        indicators,
+        datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+    )
+
+    assert projection["bias"] == "NEUTRAL"
+    assert projection["volatility"] == "HIGH"
+    assert pytest.approx(projection["range"]["low"], rel=1e-3) == 1.0 - (0.05 * 2**0.5)
+    assert pytest.approx(projection["range"]["high"], rel=1e-3) == 1.0 + (0.05 * 2**0.5)
+    assert projection["confidence"] == 30.0
+
+
+def test_decision_engine_logs_projector(monkeypatch, capfd):
+    monkeypatch.setenv("ENABLE_PROJECTOR", "true")
+
+    prices: Dict[str, List[Dict[str, float]]] = {
+        "EUR_USD": [
+            {"o": 1.0, "h": 1.1, "l": 0.9, "c": 1.0},
+            {"o": 1.0, "h": 1.1, "l": 0.9, "c": 1.1},
+        ]
+    }
+
+    def fetcher(instrument: str, **kwargs):
+        return prices[instrument]
+
+    calls: Dict[str, object] = {}
+
+    def fake_project(pair, candles, indicators, now_utc):
+        calls["pair"] = pair
+        calls["candles"] = list(candles)
+        calls["indicators"] = indicators
+        calls["ts"] = now_utc
+        return {
+            "pair": pair,
+            "timestamp": now_utc,
+            "bias": "BULL",
+            "bias_score": 0.42,
+            "range": {"low": 1.0000, "high": 1.1000},
+            "volatility": "NORMAL",
+            "confidence": 68,
+        }
+
+    monkeypatch.setattr("src.decision_engine.project_market", fake_project)
+
+    engine = DecisionEngine(
+        {
+            "instruments": ["EUR_USD"],
+            "candles_to_fetch": 2,
+            "timeframe": "M1",
+            "ema_fast": 2,
+            "ema_slow": 3,
+            "rsi_length": 2,
+            "atr_length": 2,
+            "min_atr": 0.0001,
+        },
+        candle_fetcher=fetcher,
+        now_fn=lambda: datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc),
+    )
+
+    engine.evaluate_all()
+
+    captured = capfd.readouterr().out
+    assert "[PROJECTOR] EUR_USD ts=00:00 bias=BULL score=0.42 conf=68 vol=NORMAL range=1.0000..1.1000" in captured
+    assert calls["pair"] == "EUR_USD"
+    assert calls["candles"]
+    assert calls["indicators"]["atr"] is not None


### PR DESCRIPTION
## Summary
- add a read-only market projector module to generate probabilistic bias, range, volatility, and confidence outputs
- integrate projector logging into the decision engine after indicator computation when enabled via environment variable
- add projector unit tests covering projections and integration logging

## Testing
- pytest --maxfail=1 --disable-warnings -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6950a6dcd7748329a28963fca9a9b9e8)