### PR TITLE
Harden Render worker with shared risk controls

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from typing import Dict
 
 from pydantic import AliasChoices, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -112,6 +113,22 @@ class Settings(BaseSettings):
         9,
         description="Bars to wait after a trade before considering a new one.",
     )
+    SL_ATR_MULT: float = Field(
+        1.2,
+        description="ATR multiplier applied to stop loss distance.",
+    )
+    TP_ATR_MULT: float = Field(
+        1.0,
+        description="ATR multiplier applied to take profit distance.",
+    )
+    INSTRUMENT_ATR_MULTIPLIERS: Dict[str, Dict[str, float]] = Field(
+        default_factory=dict,
+        description="Optional per-instrument overrides for ATR SL/TP multipliers.",
+    )
+    METRIC_SUMMARY_INTERVAL: int = Field(
+        10,
+        description="Decision count between summary metric log lines.",
+    )
 
     # ------------------------------------------------------------------
     # Alerting
@@ -141,5 +158,6 @@ class Settings(BaseSettings):
 
     # Trading parameters
     MAX_RISK_PER_TRADE: float = float(os.getenv("MAX_RISK_PER_TRADE", "0.02"))
+
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -1,37 +1,241 @@
+from __future__ import annotations
+
 import asyncio
+import json
+import os
 from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-from app.config import settings
-from app.strategy import decide
 from app.broker import Broker
+from app.config import settings
 from app.health import watchdog
+from app.strategy import decide
+from src.risk_setup import (
+    build_profit_protection,
+    build_risk_manager,
+    resolve_state_dir,
+)
 
 broker = Broker()
+STATE_DIR = resolve_state_dir(Path(__file__).resolve().parent.parent / "data")
+METRICS_FILE = STATE_DIR / "render_decisions.jsonl"
+SUMMARY_INTERVAL = max(1, int(settings.METRIC_SUMMARY_INTERVAL))
+
+trail_arm_pips = float(os.getenv("TRAIL_ARM_PIPS", "8.0"))
+trail_giveback_pips = float(os.getenv("TRAIL_GIVEBACK_PIPS", "4.0"))
+trail_arm_usd = float(os.getenv("TRAIL_ARM_USD", "3.0"))
+trail_giveback_usd = float(os.getenv("TRAIL_GIVEBACK_USD", "0.5"))
+be_arm_pips = float(os.getenv("BE_ARM_PIPS", "6.0"))
+be_offset_pips = float(os.getenv("BE_OFFSET_PIPS", "1.0"))
+min_check_interval_sec = float(os.getenv("TRAIL_MIN_CHECK_INTERVAL", "0.0"))
+trailing_config = {
+    "arm_pips": trail_arm_pips,
+    "giveback_pips": trail_giveback_pips,
+    "arm_usd": trail_arm_usd,
+    "giveback_usd": trail_giveback_usd,
+    "use_pips": True,
+    "be_arm_pips": be_arm_pips,
+    "be_offset_pips": be_offset_pips,
+    "min_check_interval_sec": min_check_interval_sec,
+}
+time_stop_config = {
+    "minutes": float(os.getenv("TIME_STOP_MINUTES", "90")),
+    "min_pips": float(os.getenv("TIME_STOP_MIN_PIPS", "2.0")),
+    "xau_atr_mult": float(os.getenv("TIME_STOP_XAU_ATR_MULT", "0.35")),
+}
+risk_config = {
+    "risk_per_trade_pct": settings.MAX_RISK_PER_TRADE,
+    "cooldown_candles": settings.STRAT_COOLDOWN_BARS,
+    "sl_atr_mult": settings.SL_ATR_MULT,
+    "tp_atr_mult": settings.TP_ATR_MULT,
+    "instrument_atr_multipliers": settings.INSTRUMENT_ATR_MULTIPLIERS,
+    "timeframe": settings.STRAT_TIMEFRAME,
+}
+
+risk = build_risk_manager(
+    {"risk": risk_config},
+    mode=settings.MODE,
+    demo_mode=settings.MODE.lower() == "demo",
+    state_dir=STATE_DIR,
+)
+profit_guard = build_profit_protection(
+    settings.MODE,
+    broker,
+    aggressive=False,
+    trailing=trailing_config,
+    time_stop=time_stop_config,
+)
+
+
+class DecisionMetrics:
+    def __init__(self, path: Path, summary_interval: int) -> None:
+        self.path = path
+        self.summary_interval = max(1, summary_interval)
+        self.decisions = 0
+        self.orders = 0
+        self.wins = 0
+        self.losses = 0
+        self.total_r = 0.0
+        self.r_samples = 0
+        self.max_adverse: Optional[float] = None
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._load_existing()
+
+    def _load_existing(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            with self.path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    try:
+                        payload = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    self._accumulate(payload)
+        except Exception:
+            return
+
+    def _accumulate(self, record: Dict[str, Any]) -> None:
+        self.decisions += 1
+        if record.get("order_status") == "SENT":
+            self.orders += 1
+        pl = record.get("pl")
+        if isinstance(pl, (int, float)):
+            if pl > 0:
+                self.wins += 1
+            elif pl < 0:
+                self.losses += 1
+        expected_r = record.get("expected_r")
+        if isinstance(expected_r, (int, float)) and expected_r > 0:
+            self.total_r += expected_r
+            self.r_samples += 1
+        adverse = record.get("adverse_pips")
+        if isinstance(adverse, (int, float)):
+            if self.max_adverse is None or adverse > self.max_adverse:
+                self.max_adverse = adverse
+
+    def record(self, record: Dict[str, Any]) -> None:
+        with self.path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record) + "\n")
+        self._accumulate(record)
+
+    def summary(self) -> Dict[str, Any]:
+        avg_r = self.total_r / self.r_samples if self.r_samples else None
+        total_outcomes = self.wins + self.losses
+        win_rate = (self.wins / total_outcomes) if total_outcomes else None
+        return {
+            "decisions": self.decisions,
+            "orders": self.orders,
+            "win_rate": win_rate,
+            "avg_r": avg_r,
+            "max_adverse": self.max_adverse,
+        }
+
+
+metrics = DecisionMetrics(METRICS_FILE, SUMMARY_INTERVAL)
+
 
 # Startup connectivity checks
 def _startup_checks():
     """Connectivity checks to verify credentials if provided."""
     broker.connectivity_check()
 
+
+def _entry_price_from_diag(diag: Dict[str, Any]) -> Optional[float]:
+    if not diag:
+        return None
+    for key in ("close",):
+        value = diag.get(key)
+        if isinstance(value, (int, float)):
+            return float(value)
+    closes = diag.get("closes") or []
+    if closes:
+        try:
+            return float(closes[-1])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def _order_pl(result: Dict[str, Any]) -> Optional[float]:
+    if not isinstance(result, dict):
+        return None
+    response = result.get("response") or {}
+    transactions = [
+        response.get("orderFillTransaction", {}),
+        response.get("orderCancelTransaction", {}),
+        response.get("orderCreateTransaction", {}),
+    ]
+    for tx in transactions:
+        if not isinstance(tx, dict):
+            continue
+        pl = tx.get("pl") or tx.get("profit")
+        if pl is not None:
+            try:
+                return float(pl)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _filter_closed_trades(open_trades: list[Dict[str, Any]], closed_ids: list[str]) -> list[Dict[str, Any]]:
+    if not closed_ids:
+        return open_trades
+    closed_set = set(closed_ids)
+    remaining: list[Dict[str, Any]] = []
+    for trade in open_trades:
+        tid = profit_guard._trade_id(trade)  # type: ignore[attr-defined]
+        instrument = trade.get("instrument")
+        if tid in closed_set or instrument in closed_set:
+            continue
+        remaining.append(trade)
+    return remaining
+
+
 async def heartbeat():
     """Send a heartbeat and update watchdog timestamp."""
-    # update heartbeat timestamp (UTC)
     watchdog.last_heartbeat_ts = datetime.now(timezone.utc)
     ts_local = datetime.now(timezone.utc).astimezone().isoformat()
     print(f"[HEARTBEAT] {ts_local} tz={settings.TZ} mode={settings.MODE}", flush=True)
 
+
 async def decision_tick():
     """Run the strategy decision, log diagnostics, and place demo orders."""
-    ts_local = datetime.now(timezone.utc).astimezone()
+    now_utc = datetime.now(timezone.utc)
+    equity = broker.account_equity()
+    try:
+        risk.enforce_equity_floor(now_utc, equity, close_all_cb=broker.close_all_positions)
+    except AttributeError:
+        pass
+
+    open_trades = broker.list_open_trades()
+    closed_by_trail = profit_guard.process_open_trades(open_trades)
+    if closed_by_trail:
+        open_trades = _filter_closed_trades(open_trades, closed_by_trail)
+
+    spread_pips = broker.current_spread(settings.INSTRUMENT)
+    ts_local = now_utc.astimezone()
+
     try:
         signal, reason, diag = decide()  # decide() is synchronous
     except Exception as e:
         watchdog.record_error()
         err_ts = datetime.now(timezone.utc).astimezone().isoformat()
         print(f"[ERROR] {err_ts} error={e}", flush=True)
+        metrics.record(
+            {
+                "ts": ts_local.isoformat(),
+                "instrument": settings.INSTRUMENT,
+                "signal": "ERROR",
+                "reason": str(e),
+                "order_status": "ERROR",
+            }
+        )
         return
-    # update last decision timestamp
+
     watchdog.last_decision_ts = datetime.now(timezone.utc)
     diag = diag or {}
     size_multiplier = float(diag.get("size_multiplier", 1.0))
@@ -40,13 +244,20 @@ async def decision_tick():
     if size_multiplier > 0:
         computed_size = max(1, int(settings.ORDER_SIZE * size_multiplier))
 
+    atr_val = diag.get("atr")
+    sl_distance = risk.sl_distance_from_atr(atr_val, instrument=settings.INSTRUMENT)
+    tp_distance = risk.tp_distance_from_atr(atr_val, instrument=settings.INSTRUMENT)
+    expected_r = tp_distance / sl_distance if sl_distance > 0 else None
+    entry_price = _entry_price_from_diag(diag)
+    pip_size = diag.get("pip_size") or broker._pip_size(settings.INSTRUMENT)  # type: ignore[attr-defined]
+
     log = {
         "ts": ts_local.isoformat(),
         "instrument": settings.INSTRUMENT,
         "ema_fast": diag.get("ema_fast"),
         "ema_slow": diag.get("ema_slow"),
         "rsi": diag.get("rsi"),
-        "atr": diag.get("atr"),
+        "atr": atr_val,
         "adx": diag.get("adx"),
         "session": diag.get("session"),
         "size_multiplier": size_multiplier,
@@ -54,16 +265,84 @@ async def decision_tick():
         "reason": reason,
         "mode": settings.MODE,
         "size": computed_size,
+        "sl_distance": sl_distance,
+        "tp_distance": tp_distance,
     }
     print(f"[DECISION] {log}", flush=True)
+    print(
+        f"[RISK] instrument={settings.INSTRUMENT} atr={atr_val} sl_dist={sl_distance:.5f} tp_dist={tp_distance:.5f}",
+        flush=True,
+    )
+
+    order_status = "SKIPPED"
+    broker_response: Dict[str, Any] | None = None
     if signal in ("BUY", "SELL"):
         if computed_size <= 0:
             print(
                 f"[BROKER] Skipping order {signal} for {settings.INSTRUMENT} due to zero size",
                 flush=True,
             )
-            return
-        broker.place_order(settings.INSTRUMENT, signal, computed_size)
+            order_status = "BLOCKED"
+        else:
+            ok_to_open, risk_reason = risk.should_open(
+                now_utc,
+                equity,
+                open_trades,
+                settings.INSTRUMENT,
+                spread_pips,
+            )
+            if not ok_to_open:
+                print(
+                    f"[TRADE] Skipping {settings.INSTRUMENT} due to {risk_reason}",
+                    flush=True,
+                )
+                order_status = "BLOCKED"
+            else:
+                broker_response = broker.place_order(
+                    settings.INSTRUMENT,
+                    signal,
+                    computed_size,
+                    sl_distance=sl_distance,
+                    tp_distance=tp_distance,
+                    entry_price=entry_price,
+                )
+                order_status = broker_response.get("status", "UNKNOWN")
+                if order_status == "SENT":
+                    risk.register_entry(now_utc, settings.INSTRUMENT)
+    adverse_pips = spread_pips if spread_pips is not None else None
+    pl = _order_pl(broker_response or {})
+    metrics_payload = {
+        "ts": ts_local.isoformat(),
+        "instrument": settings.INSTRUMENT,
+        "signal": signal,
+        "reason": reason,
+        "size": computed_size,
+        "size_multiplier": size_multiplier,
+        "atr": atr_val,
+        "sl_distance": sl_distance,
+        "tp_distance": tp_distance,
+        "expected_r": expected_r,
+        "entry_price": entry_price,
+        "spread_pips": spread_pips,
+        "adverse_pips": adverse_pips,
+        "pip_size": pip_size,
+        "order_status": order_status,
+        "response": broker_response,
+        "pl": pl,
+    }
+    metrics.record(metrics_payload)
+
+    if metrics.decisions % SUMMARY_INTERVAL == 0:
+        snapshot = metrics.summary()
+        win_rate_pct = f"{snapshot['win_rate'] * 100:.1f}%" if snapshot["win_rate"] is not None else "n/a"
+        avg_r_fmt = f"{snapshot['avg_r']:.2f}" if snapshot["avg_r"] is not None else "n/a"
+        adverse_fmt = f"{snapshot['max_adverse']:.2f}" if snapshot["max_adverse"] is not None else "n/a"
+        print(
+            f"[METRICS] decisions={snapshot['decisions']} orders={snapshot['orders']} "
+            f"win_rate={win_rate_pct} avg_R={avg_r_fmt} max_adverse_pips={adverse_fmt}",
+            flush=True,
+        )
+
 
 async def runner():
     """Main runner scheduling heartbeat and decision tasks and running watchdog."""
@@ -77,6 +356,7 @@ async def runner():
     await decision_tick()
     while True:
         await asyncio.sleep(3600)
+
 
 if __name__ == "__main__":
     asyncio.run(runner())

--- a/app/strategy.py
+++ b/app/strategy.py
@@ -15,6 +15,16 @@ ASIA_ADX_THRESHOLD = 25.0
 ASIA_SIZE_MULTIPLIER = 0.5
 
 
+def _pip_size(instrument: str) -> float:
+    if instrument.endswith("JPY"):
+        return 0.01
+    if instrument.startswith("XAU"):
+        return 0.1
+    if instrument.startswith("XAG"):
+        return 0.01
+    return 0.0001
+
+
 def _current_session(now_utc: datetime) -> str:
     """Return the trading session label based on the UTC hour."""
 
@@ -234,6 +244,7 @@ def decide() -> Tuple[Signal, str, Dict]:
     rsi_val = _rsi(closes, rsi_len)
     atr_val = _atr(highs, lows, closes, atr_len)
     adx_val = _adx(highs, lows, closes, adx_len)
+    pip_size = _pip_size(settings.INSTRUMENT)
 
     now_utc = datetime.now(timezone.utc)
     allowed, size_mult, session = _session_gate(now_utc, adx_val)
@@ -245,6 +256,13 @@ def decide() -> Tuple[Signal, str, Dict]:
         "adx": adx_val,
         "session": session,
         "size_multiplier": size_mult,
+        "close": closes[-1],
+        "high": highs[-1],
+        "low": lows[-1],
+        "closes": closes[-5:],
+        "highs": highs[-5:],
+        "lows": lows[-5:],
+        "pip_size": pip_size,
     }
 
     if not allowed:

--- a/src/risk_setup.py
+++ b/src/risk_setup.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+from src.profit_protection import ProfitProtection
+from src.risk_manager import RiskManager
+
+
+DEFAULT_TRAILING_CONFIG = {
+    "arm_pips": 8.0,
+    "giveback_pips": 4.0,
+    "arm_usd": 3.0,
+    "giveback_usd": 0.5,
+    "use_pips": True,
+    "be_arm_pips": 6.0,
+    "be_offset_pips": 1.0,
+    "min_check_interval_sec": 0.0,
+}
+
+DEFAULT_TIME_STOP = {
+    "minutes": 90.0,
+    "min_pips": 2.0,
+    "xau_atr_mult": 0.35,
+}
+
+
+def resolve_state_dir(fallback: Optional[Path] = None) -> Path:
+    """Return the state directory honoring MOSSY_STATE_PATH when set."""
+
+    root = os.getenv("MOSSY_STATE_PATH")
+    base = Path(root) if root else (fallback or Path("data"))
+    base.mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def build_risk_manager(
+    config: Dict,
+    *,
+    mode: str,
+    demo_mode: bool = False,
+    state_dir: Optional[Path] = None,
+) -> RiskManager:
+    """Instantiate a RiskManager with consistent state handling."""
+
+    risk_config = config.get("risk") if "risk" in config else config
+    state_path = resolve_state_dir(state_dir)
+    return RiskManager(
+        risk_config or {},
+        mode=mode,
+        state_dir=state_path,
+        demo_mode=demo_mode,
+    )
+
+
+def build_profit_protection(
+    mode: str,
+    broker,
+    aggressive: bool = False,
+    *,
+    trailing: Optional[Dict] = None,
+    time_stop: Optional[Dict] = None,
+) -> ProfitProtection:
+    """Create ProfitProtection consistent with deployment mode."""
+
+    trailing_cfg = DEFAULT_TRAILING_CONFIG | (trailing or {})
+    ts_cfg = DEFAULT_TIME_STOP | (time_stop or {})
+    ts_minutes = float(ts_cfg.get("minutes", DEFAULT_TIME_STOP["minutes"]))
+    ts_min_pips = float(ts_cfg.get("min_pips", DEFAULT_TIME_STOP["min_pips"]))
+    ts_xau_mult = float(ts_cfg.get("xau_atr_mult", DEFAULT_TIME_STOP["xau_atr_mult"]))
+
+    if aggressive:
+        return ProfitProtection(
+            broker,
+            trigger=5.0,
+            trail=1.5,
+            arm_usd=5.0,
+            giveback_usd=1.5,
+            arm_pips=trailing_cfg["arm_pips"],
+            giveback_pips=trailing_cfg["giveback_pips"],
+            use_pips=trailing_cfg["use_pips"],
+            be_arm_pips=trailing_cfg["be_arm_pips"],
+            be_offset_pips=trailing_cfg["be_offset_pips"],
+            min_check_interval_sec=trailing_cfg["min_check_interval_sec"],
+            aggressive=True,
+            aggressive_max_hold_minutes=float(trailing_cfg.get("aggressive_max_hold_minutes", 45.0)),
+            aggressive_max_loss_usd=float(trailing_cfg.get("aggressive_max_loss_usd", 5.0)),
+            aggressive_max_loss_atr_mult=float(trailing_cfg.get("aggressive_max_loss_atr_mult", 1.2)),
+            time_stop_minutes=ts_minutes,
+            time_stop_min_pips=ts_min_pips,
+            time_stop_xau_atr_mult=ts_xau_mult,
+        )
+
+    label = (mode or "").lower()
+    if label == "demo":
+        return ProfitProtection(
+            broker,
+            trigger=1.0,
+            trail=0.5,
+            arm_usd=1.0,
+            giveback_usd=0.5,
+            arm_pips=trailing_cfg["arm_pips"],
+            giveback_pips=trailing_cfg["giveback_pips"],
+            use_pips=trailing_cfg["use_pips"],
+            be_arm_pips=trailing_cfg["be_arm_pips"],
+            be_offset_pips=trailing_cfg["be_offset_pips"],
+            min_check_interval_sec=trailing_cfg["min_check_interval_sec"],
+            time_stop_minutes=ts_minutes,
+            time_stop_min_pips=ts_min_pips,
+            time_stop_xau_atr_mult=ts_xau_mult,
+        )
+
+    return ProfitProtection(
+        broker,
+        trigger=3.0,
+        trail=0.5,
+        arm_usd=trailing_cfg["arm_usd"],
+        giveback_usd=trailing_cfg["giveback_usd"],
+        arm_pips=trailing_cfg["arm_pips"],
+        giveback_pips=trailing_cfg["giveback_pips"],
+        use_pips=trailing_cfg["use_pips"],
+        be_arm_pips=trailing_cfg["be_arm_pips"],
+        be_offset_pips=trailing_cfg["be_offset_pips"],
+        min_check_interval_sec=trailing_cfg["min_check_interval_sec"],
+        time_stop_minutes=ts_minutes,
+        time_stop_min_pips=ts_min_pips,
+        time_stop_xau_atr_mult=ts_xau_mult,
+    )


### PR DESCRIPTION
## Summary
- extract shared risk/profit protection setup and apply it to both the main engine and Render worker
- add ATR-based SL/TP configuration plus richer diagnostics for Render strategy decisions
- wrap Render decisions with RiskManager/ProfitProtection, logging applied distances and persisting decision metrics with rolling summaries

## Testing
- python -m compileall app src

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69526ae8df208329b1310efbf1d94e1f)