### PR TITLE
Fix stop-loss distance precision for OANDA orders

### DIFF
--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -86,6 +86,25 @@ def test_place_order_uses_absolute_tp_price_for_sell(monkeypatch):
     assert "distance" not in order["takeProfitOnFill"]
 
 
+def test_stop_loss_distance_respects_instrument_precision(monkeypatch):
+    _configure_settings(monkeypatch)
+    recorded = {}
+    monkeypatch.setattr(Broker, "_client", lambda self: DummyClient(recorded))
+
+    broker = Broker()
+    result = broker.place_order(
+        "USD_JPY",
+        "SELL",
+        50,
+        sl_distance=0.06901,
+    )
+
+    assert result["status"] == "SENT"
+    order = recorded["payload"]["order"]
+    assert order["units"] == "-50"
+    assert order["stopLossOnFill"]["distance"] == "0.069"
+
+
 def test_usd_jpy_tp_price_is_rounded(monkeypatch, capsys):
     _configure_settings(monkeypatch)
     recorded = {}


### PR DESCRIPTION
## Summary
- normalize price and stop-loss rounding using instrument-specific precision
- ensure USD_JPY stop-loss distances comply with OANDA precision requirements
- add coverage for stop-loss distance formatting in broker tests

## Testing
- pytest tests/test_broker.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695293337ac48329a654d6beb8e60a3f)