### PR TITLE
Add opening range breakout session filter and MACD confirmation updates

### DIFF
--- a/src/decision_engine.py
+++ b/src/decision_engine.py
@@ -364,6 +364,12 @@ class DecisionEngine:
             slow_length=26,
             signal_length=9,
         )
+        macd_line_prev, macd_signal_prev, macd_histogram_prev = calculate_macd(
+            closes[:-1],
+            fast_length=12,
+            slow_length=26,
+            signal_length=9,
+        )
 
         last_close = closes[-1] if closes else math.nan
         return {
@@ -378,6 +384,7 @@ class DecisionEngine:
             "macd_line": macd_line,
             "macd_signal": macd_signal,
             "macd_histogram": macd_histogram,
+            "macd_histogram_prev": macd_histogram_prev,
         }
 
     def _generate_signal(self, diagnostics: Dict[str, float]) -> (str, str):

--- a/src/orb.py
+++ b/src/orb.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Dict, Optional, Tuple
+
+from src.session_filter import SessionSnapshot
+
+
+@dataclass
+class OpeningRange:
+    high: float
+    low: float
+    start_utc: datetime
+    end_utc: datetime
+    finalized: bool
+
+    def as_tuple(self) -> Tuple[float, float]:
+        return self.high, self.low
+
+
+_ranges: Dict[str, OpeningRange] = {}
+
+
+def _range_key(instrument: str, session: SessionSnapshot) -> str:
+    return f"{session.session_id}:{instrument.upper()}"
+
+
+def reset_for_session(session: SessionSnapshot) -> None:
+    keys_to_delete = [key for key in _ranges if not key.startswith(f"{session.session_id}:")]
+    for key in keys_to_delete:
+        _ranges.pop(key, None)
+
+
+def update_opening_range(
+    instrument: str,
+    session: SessionSnapshot,
+    *,
+    candle_high: float,
+    candle_low: float,
+    now_utc: datetime,
+    range_minutes: int = 15,
+) -> OpeningRange:
+    key = _range_key(instrument, session)
+    existing = _ranges.get(key)
+    range_end = session.start_utc + timedelta(minutes=range_minutes)
+
+    if existing is None:
+        existing = OpeningRange(
+            high=candle_high,
+            low=candle_low,
+            start_utc=session.start_utc,
+            end_utc=range_end,
+            finalized=False,
+        )
+        _ranges[key] = existing
+
+    if now_utc <= range_end:
+        existing.high = max(existing.high, candle_high)
+        existing.low = min(existing.low, candle_low)
+    else:
+        existing.finalized = True
+
+    if now_utc >= range_end:
+        existing.finalized = True
+
+    return existing
+
+
+def opening_range_for(instrument: str, session: SessionSnapshot) -> Optional[OpeningRange]:
+    return _ranges.get(_range_key(instrument, session))
+
+
+def breakout_direction(close_price: float, opening_range: OpeningRange) -> Optional[str]:
+    if close_price > opening_range.high:
+        return "BUY"
+    if close_price < opening_range.low:
+        return "SELL"
+    return None
+
+
+__all__ = ["OpeningRange", "opening_range_for", "update_opening_range", "reset_for_session", "breakout_direction"]

--- a/src/session_filter.py
+++ b/src/session_filter.py
@@ -1,27 +1,106 @@
 from __future__ import annotations
 
-from datetime import datetime, time, timezone
+from dataclasses import dataclass
+from datetime import date, datetime, time, timedelta, timezone
+import os
+from typing import Iterable, List, Optional
 
 
-_LONDON_START = time(7, 0)
-_LONDON_END = time(16, 0)
-_NY_CORE_START = time(12, 0)
-_NY_CORE_END = time(21, 0)
+AWST = timezone(timedelta(hours=8))
 
 
-def _is_in_window(current: time, start: time, end: time) -> bool:
-    return start <= current < end
+@dataclass(frozen=True)
+class SessionSnapshot:
+    name: str
+    start_awst: datetime
+    end_awst: datetime
+    start_utc: datetime
+    end_utc: datetime
+
+    @property
+    def session_id(self) -> str:
+        start_date = self.start_awst.date().isoformat()
+        start_ts = self.start_awst.strftime("%H%M")
+        return f"{self.name}-{start_date}-{start_ts}"
+
+
+def _parse_awst_time(value: Optional[str], fallback: time) -> time:
+    if not value:
+        return fallback
+    parts = str(value).split(":")
+    if len(parts) < 2:
+        return fallback
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+        return time(hour, minute)
+    except (TypeError, ValueError):
+        return fallback
+
+
+def _window_bounds(day: date, start: time, end: time) -> tuple[datetime, datetime]:
+    start_dt = datetime.combine(day, start, tzinfo=AWST)
+    end_dt = datetime.combine(day, end, tzinfo=AWST)
+    if end_dt <= start_dt:
+        end_dt += timedelta(days=1)
+    return start_dt, end_dt
+
+
+def _windows_from_env() -> List[tuple[str, time, time]]:
+    london_start = _parse_awst_time(os.getenv("LONDON_SESSION_START_AWST"), time(15, 0))
+    london_end = _parse_awst_time(os.getenv("LONDON_SESSION_END_AWST"), time(0, 0))
+    ny_start = _parse_awst_time(os.getenv("NY_SESSION_START_AWST"), time(20, 0))
+    ny_end = _parse_awst_time(os.getenv("NY_SESSION_END_AWST"), time(5, 0))
+    return [
+        ("london", london_start, london_end),
+        ("newyork", ny_start, ny_end),
+    ]
+
+
+def _session_for_window(now_awst: datetime, *, name: str, start: time, end: time) -> SessionSnapshot | None:
+    for day_offset in (0, -1):
+        anchor_day = (now_awst.date() + timedelta(days=day_offset))
+        start_dt, end_dt = _window_bounds(anchor_day, start, end)
+        if start_dt <= now_awst < end_dt:
+            return SessionSnapshot(
+                name=name,
+                start_awst=start_dt,
+                end_awst=end_dt,
+                start_utc=start_dt.astimezone(timezone.utc),
+                end_utc=end_dt.astimezone(timezone.utc),
+            )
+    return None
+
+
+def current_session(now_utc: datetime, *, mode: str | None = None) -> SessionSnapshot | None:
+    awst_now = now_utc.astimezone(AWST)
+    for name, start, end in _windows_from_env():
+        session = _session_for_window(awst_now, name=name, start=start, end=end)
+        if session:
+            return session
+    return None
+
+
+_last_session: SessionSnapshot | None = None
 
 
 def is_entry_session(now_utc: datetime, *, mode: str | None = None) -> bool:
     """Return True if new entries are allowed for the given UTC timestamp."""
 
-    aware = now_utc.astimezone(timezone.utc)
-    current_time = aware.time()
+    global _last_session
+    session = current_session(now_utc, mode=mode)
+    if session and (_last_session is None or session.session_id != _last_session.session_id):
+        print(
+            f"[SESSION] Start {session.name} awst={session.start_awst.strftime('%H:%M')}..{session.end_awst.strftime('%H:%M')}",
+            flush=True,
+        )
+    if _last_session and (session is None or session.session_id != _last_session.session_id):
+        print(
+            f"[SESSION] End {_last_session.name} awst={_last_session.end_awst.strftime('%H:%M')}",
+            flush=True,
+        )
+    _last_session = session
+    return session is not None
 
-    in_london = _is_in_window(current_time, _LONDON_START, _LONDON_END)
-    in_ny = _is_in_window(current_time, _NY_CORE_START, _NY_CORE_END)
-    return in_london or in_ny
 
-
-__all__ = ["is_entry_session"]
+__all__ = ["is_entry_session", "current_session", "SessionSnapshot", "AWST"]

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -178,6 +178,11 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                     },
                     reason="trend",
                     market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
                 )
             ]
 
@@ -362,6 +367,11 @@ def test_decision_cycle_blocks_entries_outside_session(monkeypatch, capsys):
                     },
                     reason="trend",
                     market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
                 )
             ]
 
@@ -487,6 +497,11 @@ def test_decision_cycle_blocks_entries_on_weekend(monkeypatch, capsys):
                     },
                     reason="trend",
                     market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
                 )
             ]
 
@@ -611,6 +626,11 @@ def test_decision_cycle_allows_entries_inside_session(monkeypatch):
                     },
                     reason="trend",
                     market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
                 )
             ]
 
@@ -728,6 +748,11 @@ def test_live_mode_ignores_weekend_lock(monkeypatch, capsys):
                     },
                     reason="trend",
                     market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
                 )
             ]
 

--- a/tests/test_macd_confirmation.py
+++ b/tests/test_macd_confirmation.py
@@ -164,6 +164,11 @@ def test_macd_confirmation_allows_trade(monkeypatch):
                     },
                     reason="bullish",
                     market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
                 )
             ]
 
@@ -400,6 +405,11 @@ def test_macd_confirms_fx_and_xau(monkeypatch):
                     },
                     reason="bullish",
                     market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
                 ),
                 Evaluation(
                     instrument="XAU_USD",
@@ -408,7 +418,7 @@ def test_macd_confirms_fx_and_xau(monkeypatch):
                         "atr": 1.2,
                         "atr_baseline_50": 1.0,
                         "rsi": 45.0,
-                        "close": 1900.0,
+                        "close": 1898.0,
                         "ema_trend_fast": 1890.0,
                         "ema_trend_slow": 1900.0,
                         "macd_line": -0.5,
@@ -417,6 +427,11 @@ def test_macd_confirms_fx_and_xau(monkeypatch):
                     },
                     reason="bearish",
                     market_active=True,
+                    candles=[
+                        {"o": 1901.0, "h": 1905.0, "l": 1899.0, "c": 1902.0},
+                        {"o": 1902.0, "h": 1903.0, "l": 1900.0, "c": 1901.5},
+                        {"o": 1901.5, "h": 1902.0, "l": 1900.5, "c": 1901.0},
+                    ],
                 ),
             ]
 
@@ -471,3 +486,17 @@ def test_macd_confirms_fx_and_xau(monkeypatch):
     assert dummy_risk.entries == ["EUR_USD", "XAU_USD"]
     watchdog.last_decision_ts = original_ts
     _reset_clock(original_datetime)
+
+
+def test_macd_histogram_rising_allows_negative_hist(monkeypatch):
+    monkeypatch.setitem(main.config, "use_macd_confirmation", True)
+    macd_result = main._macd_confirms(
+        "BUY",
+        {
+            "macd_line": 0.5,
+            "macd_signal": 0.1,
+            "macd_histogram": -0.01,
+            "macd_histogram_prev": -0.05,
+        },
+    )
+    assert macd_result[0] is True

--- a/tests/test_orb.py
+++ b/tests/test_orb.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src import orb
+from src.session_filter import SessionSnapshot, AWST
+
+
+def _session(start_awst: datetime) -> SessionSnapshot:
+    end_awst = start_awst + timedelta(hours=1)
+    return SessionSnapshot(
+        name="london",
+        start_awst=start_awst,
+        end_awst=end_awst,
+        start_utc=start_awst.astimezone(timezone.utc),
+        end_utc=end_awst.astimezone(timezone.utc),
+    )
+
+
+def test_opening_range_updates_and_finalizes():
+    start_awst = datetime(2024, 1, 1, 15, 0, tzinfo=AWST)
+    session = _session(start_awst)
+    now = session.start_utc + timedelta(minutes=5)
+    rng = orb.update_opening_range("EUR_USD", session, candle_high=1.1, candle_low=1.0, now_utc=now)
+    assert rng.high == 1.1
+    assert rng.low == 1.0
+    assert rng.finalized is False
+
+    later = session.start_utc + timedelta(minutes=16)
+    rng = orb.update_opening_range("EUR_USD", session, candle_high=1.05, candle_low=0.99, now_utc=later)
+    assert rng.finalized is True
+    assert rng.high == 1.1
+    assert rng.low == 1.0
+
+
+def test_breakout_direction_buy_and_sell():
+    start_awst = datetime(2024, 1, 1, 15, 0, tzinfo=AWST)
+    session = _session(start_awst)
+    now = session.start_utc + timedelta(minutes=16)
+    rng = orb.update_opening_range("GBP_USD", session, candle_high=1.2, candle_low=1.1, now_utc=now)
+    rng.finalized = True
+
+    assert orb.breakout_direction(1.2001, rng) == "BUY"
+    assert orb.breakout_direction(1.0999, rng) == "SELL"
+    assert orb.breakout_direction(1.15, rng) is None

--- a/tests/test_session_filter.py
+++ b/tests/test_session_filter.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-from src.session_filter import is_entry_session
+import os
+
+from src.session_filter import AWST, SessionSnapshot, current_session, is_entry_session
 
 
 def _utc(hour: int, minute: int = 0) -> datetime:
@@ -19,3 +21,20 @@ def test_entry_allowed_overlap_session():
 
 def test_entry_blocked_outside_session():
     assert is_entry_session(_utc(22, 0)) is False
+
+
+def test_session_snapshot_respects_env(monkeypatch):
+    monkeypatch.setenv("LONDON_SESSION_START_AWST", "10:00")
+    monkeypatch.setenv("LONDON_SESSION_END_AWST", "12:00")
+    now = datetime(2024, 1, 1, 3, 30, tzinfo=timezone.utc)  # 11:30 AWST
+    session = current_session(now)
+    assert session is not None
+    assert session.name == "london"
+    assert session.start_awst.tzinfo == AWST
+
+
+def test_session_snapshot_none_when_outside(monkeypatch):
+    monkeypatch.delenv("LONDON_SESSION_START_AWST", raising=False)
+    monkeypatch.delenv("LONDON_SESSION_END_AWST", raising=False)
+    now = datetime(2024, 1, 1, 5, 10, tzinfo=timezone.utc)  # 13:10 AWST, outside defaults
+    assert current_session(now) is None


### PR DESCRIPTION
## Summary
- add AWST-configurable session windows plus per-session opening range tracking for instruments
- gate entries on opening-range breakout with MACD histogram confirmation while preserving existing risk controls
- extend and update unit tests for sessions, ORB calculations, MACD behavior, and decision flow

## Testing
- pytest -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695354ccf4e08329a374b0b882a3d172)