### PR TITLE
Increase default daily trade cap to 50 trades

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -64,7 +64,7 @@
       "start": "04:55",
       "end": "05:05"
     },
-    "max_trades_per_day": 8
+    "max_trades_per_day": 50
   },
   "trailing": {
     "arm_pips": 8.0,


### PR DESCRIPTION
## Summary
- raise the default risk configuration for max_trades_per_day from 8 to 50 trades to match updated throughput target

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695395e63154832985d0db84653a27c1)