### PR TITLE
Enforce USD-based profit protection logic

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -24,9 +24,9 @@ STATE_DIR = resolve_state_dir(Path(__file__).resolve().parent.parent / "data")
 METRICS_FILE = STATE_DIR / "render_decisions.jsonl"
 SUMMARY_INTERVAL = max(1, int(settings.METRIC_SUMMARY_INTERVAL))
 
-trail_arm_pips = float(os.getenv("TRAIL_ARM_PIPS", "8.0"))
-trail_giveback_pips = float(os.getenv("TRAIL_GIVEBACK_PIPS", "4.0"))
-trail_arm_usd = float(os.getenv("TRAIL_ARM_USD", "3.0"))
+trail_arm_pips = float(os.getenv("TRAIL_ARM_PIPS", "0.0"))
+trail_giveback_pips = float(os.getenv("TRAIL_GIVEBACK_PIPS", "0.0"))
+trail_arm_usd = float(os.getenv("TRAIL_ARM_USD", "0.75"))
 trail_giveback_usd = float(os.getenv("TRAIL_GIVEBACK_USD", "0.5"))
 be_arm_pips = float(os.getenv("BE_ARM_PIPS", "6.0"))
 be_offset_pips = float(os.getenv("BE_OFFSET_PIPS", "1.0"))
@@ -36,7 +36,7 @@ trailing_config = {
     "giveback_pips": trail_giveback_pips,
     "arm_usd": trail_arm_usd,
     "giveback_usd": trail_giveback_usd,
-    "use_pips": True,
+    "use_pips": False,
     "be_arm_pips": be_arm_pips,
     "be_offset_pips": be_offset_pips,
     "min_check_interval_sec": min_check_interval_sec,
@@ -246,7 +246,7 @@ async def decision_tick():
 
     atr_val = diag.get("atr")
     sl_distance = risk.sl_distance_from_atr(atr_val, instrument=settings.INSTRUMENT)
-    tp_distance = risk.tp_distance_from_atr(atr_val, instrument=settings.INSTRUMENT)
+    tp_distance = 0.0  # Disable standard TP to avoid interfering with USD-based profit protection
     expected_r = tp_distance / sl_distance if sl_distance > 0 else None
     entry_price = _entry_price_from_diag(diag)
     pip_size = diag.get("pip_size") or broker._pip_size(settings.INSTRUMENT)  # type: ignore[attr-defined]

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -67,13 +67,13 @@
     "max_trades_per_day": 50
   },
   "trailing": {
-    "arm_pips": 8.0,
-    "giveback_pips": 4.0,
-    "arm_usd": 3.0,
+    "arm_pips": 0.0,
+    "giveback_pips": 0.0,
+    "arm_usd": 0.75,
     "giveback_usd": 0.5,
-    "use_pips": true,
-    "be_arm_pips": 6.0,
-    "be_offset_pips": 1.0,
+    "use_pips": false,
+    "be_arm_pips": 0.0,
+    "be_offset_pips": 0.0,
     "min_check_interval_sec": 0.0
   },
   "time_stop": {

--- a/src/main.py
+++ b/src/main.py
@@ -162,13 +162,13 @@ aggressive_max_hold_minutes = float(os.getenv("AGGRESSIVE_MAX_HOLD_MINUTES", con
 aggressive_max_loss_usd = float(os.getenv("AGGRESSIVE_MAX_LOSS_USD", config.get("aggressive_max_loss_usd", 5.0)))
 aggressive_max_loss_atr_mult = float(os.getenv("AGGRESSIVE_MAX_LOSS_ATR_MULT", config.get("aggressive_max_loss_atr_mult", 1.2)))
 trailing_config = config.get("trailing", {}) or {}
-trail_use_pips = _as_bool(os.getenv("TRAIL_USE_PIPS", trailing_config.get("use_pips", True)))
-trail_arm_pips = float(os.getenv("TRAIL_ARM_PIPS", trailing_config.get("arm_pips", 8.0)))
-trail_giveback_pips = float(os.getenv("TRAIL_GIVEBACK_PIPS", trailing_config.get("giveback_pips", 4.0)))
-trail_arm_usd = float(os.getenv("TRAIL_ARM_USD", trailing_config.get("arm_usd", 3.0)))
+trail_use_pips = False
+trail_arm_pips = float(os.getenv("TRAIL_ARM_PIPS", trailing_config.get("arm_pips", 0.0)))
+trail_giveback_pips = float(os.getenv("TRAIL_GIVEBACK_PIPS", trailing_config.get("giveback_pips", 0.0)))
+trail_arm_usd = float(os.getenv("TRAIL_ARM_USD", trailing_config.get("arm_usd", 0.75)))
 trail_giveback_usd = float(os.getenv("TRAIL_GIVEBACK_USD", trailing_config.get("giveback_usd", 0.5)))
-be_arm_pips = float(os.getenv("BE_ARM_PIPS", trailing_config.get("be_arm_pips", 6.0)))
-be_offset_pips = float(os.getenv("BE_OFFSET_PIPS", trailing_config.get("be_offset_pips", 1.0)))
+be_arm_pips = float(os.getenv("BE_ARM_PIPS", trailing_config.get("be_arm_pips", 0.0)))
+be_offset_pips = float(os.getenv("BE_OFFSET_PIPS", trailing_config.get("be_offset_pips", 0.0)))
 min_check_interval_sec = float(os.getenv("MIN_CHECK_INTERVAL_SEC", trailing_config.get("min_check_interval_sec", 0.0)))
 trailing_config = {
     "arm_pips": trail_arm_pips,
@@ -732,7 +732,7 @@ async def decision_cycle() -> None:
 
             atr_val = diagnostics.get("atr")
             sl_distance = risk.sl_distance_from_atr(atr_val, instrument=evaluation.instrument)
-            tp_distance = risk.tp_distance_from_atr(atr_val, instrument=evaluation.instrument)
+            tp_distance = 0.0  # Disable standard TP to avoid interfering with USD-based profit protection
             entry_price = diagnostics.get("close")
 
             if not trend_ok:

--- a/src/risk_setup.py
+++ b/src/risk_setup.py
@@ -9,13 +9,13 @@ from src.risk_manager import RiskManager
 
 
 DEFAULT_TRAILING_CONFIG = {
-    "arm_pips": 8.0,
-    "giveback_pips": 4.0,
-    "arm_usd": 3.0,
+    "arm_pips": 0.0,
+    "giveback_pips": 0.0,
+    "arm_usd": 0.75,
     "giveback_usd": 0.5,
-    "use_pips": True,
-    "be_arm_pips": 6.0,
-    "be_offset_pips": 1.0,
+    "use_pips": False,
+    "be_arm_pips": 0.0,
+    "be_offset_pips": 0.0,
     "min_check_interval_sec": 0.0,
 }
 
@@ -70,59 +70,22 @@ def build_profit_protection(
     ts_min_pips = float(ts_cfg.get("min_pips", DEFAULT_TIME_STOP["min_pips"]))
     ts_xau_mult = float(ts_cfg.get("xau_atr_mult", DEFAULT_TIME_STOP["xau_atr_mult"]))
 
-    if aggressive:
-        return ProfitProtection(
-            broker,
-            trigger=5.0,
-            trail=1.5,
-            arm_usd=5.0,
-            giveback_usd=1.5,
-            arm_pips=trailing_cfg["arm_pips"],
-            giveback_pips=trailing_cfg["giveback_pips"],
-            use_pips=trailing_cfg["use_pips"],
-            be_arm_pips=trailing_cfg["be_arm_pips"],
-            be_offset_pips=trailing_cfg["be_offset_pips"],
-            min_check_interval_sec=trailing_cfg["min_check_interval_sec"],
-            aggressive=True,
-            aggressive_max_hold_minutes=float(trailing_cfg.get("aggressive_max_hold_minutes", 45.0)),
-            aggressive_max_loss_usd=float(trailing_cfg.get("aggressive_max_loss_usd", 5.0)),
-            aggressive_max_loss_atr_mult=float(trailing_cfg.get("aggressive_max_loss_atr_mult", 1.2)),
-            time_stop_minutes=ts_minutes,
-            time_stop_min_pips=ts_min_pips,
-            time_stop_xau_atr_mult=ts_xau_mult,
-        )
-
-    label = (mode or "").lower()
-    if label == "demo":
-        return ProfitProtection(
-            broker,
-            trigger=1.0,
-            trail=0.5,
-            arm_usd=1.0,
-            giveback_usd=0.5,
-            arm_pips=trailing_cfg["arm_pips"],
-            giveback_pips=trailing_cfg["giveback_pips"],
-            use_pips=trailing_cfg["use_pips"],
-            be_arm_pips=trailing_cfg["be_arm_pips"],
-            be_offset_pips=trailing_cfg["be_offset_pips"],
-            min_check_interval_sec=trailing_cfg["min_check_interval_sec"],
-            time_stop_minutes=ts_minutes,
-            time_stop_min_pips=ts_min_pips,
-            time_stop_xau_atr_mult=ts_xau_mult,
-        )
-
     return ProfitProtection(
         broker,
-        trigger=3.0,
-        trail=0.5,
+        trigger=trailing_cfg["arm_usd"],
+        trail=trailing_cfg["giveback_usd"],
         arm_usd=trailing_cfg["arm_usd"],
         giveback_usd=trailing_cfg["giveback_usd"],
         arm_pips=trailing_cfg["arm_pips"],
         giveback_pips=trailing_cfg["giveback_pips"],
-        use_pips=trailing_cfg["use_pips"],
+        use_pips=False,
         be_arm_pips=trailing_cfg["be_arm_pips"],
         be_offset_pips=trailing_cfg["be_offset_pips"],
         min_check_interval_sec=trailing_cfg["min_check_interval_sec"],
+        aggressive=aggressive,
+        aggressive_max_hold_minutes=float(trailing_cfg.get("aggressive_max_hold_minutes", 45.0)),
+        aggressive_max_loss_usd=float(trailing_cfg.get("aggressive_max_loss_usd", 5.0)),
+        aggressive_max_loss_atr_mult=float(trailing_cfg.get("aggressive_max_loss_atr_mult", 1.2)),
         time_stop_minutes=ts_minutes,
         time_stop_min_pips=ts_min_pips,
         time_stop_xau_atr_mult=ts_xau_mult,

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -266,7 +266,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
                 "signal": "BUY",
                 "units": 100,
                 "sl_distance": expected_sl,
-                "tp_distance": dummy_risk.tp_distance_from_atr(0.01),
+                "tp_distance": 0.0,
                 "entry_price": 1.2345,
             }
         ]

--- a/tests/test_profit_protection.py
+++ b/tests/test_profit_protection.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 import pytest
 
+import src.profit_protection as profit_protection
 from src.profit_protection import ProfitProtection
 from src.decision_engine import Evaluation
 from src import main as main_mod
@@ -40,16 +47,16 @@ class DummyBroker:
         return 0.0001
 
 
-def _trade(trade_id: str, instrument: str, units: float, pips: float | None = None, profit: float | None = None):
+def _trade(trade_id: str, instrument: str, units: float, profit: float | None = None, pips: float | None = None):
     payload = {
         "id": trade_id,
         "instrument": instrument,
         "currentUnits": units,
     }
-    if pips is not None:
-        payload["unrealizedPips"] = pips
     if profit is not None:
         payload["unrealizedPL"] = profit
+    if pips is not None:
+        payload["unrealizedPips"] = pips
     return payload
 
 
@@ -57,57 +64,55 @@ def test_trailing_giveback_closes_at_floor(capsys):
     broker = DummyBroker()
     guard = ProfitProtection(
         broker,
-        arm_pips=8,
-        giveback_pips=4,
-        use_pips=True,
-        be_arm_pips=20,  # keep break-even out of the way
+        arm_usd=0.75,
+        giveback_usd=0.5,
     )
 
-    trade = _trade("T1", "EUR_USD", 1000, pips=0)
+    trade = _trade("T1", "EUR_USD", 1000, profit=0.0)
     guard.process_open_trades([trade])
 
-    trade = _trade("T1", "EUR_USD", 1000, pips=10)
+    trade = _trade("T1", "EUR_USD", 1000, profit=0.8)
     guard.process_open_trades([trade])
 
-    trade = _trade("T1", "EUR_USD", 1000, pips=12)
+    trade = _trade("T1", "EUR_USD", 1000, profit=1.20)
     guard.process_open_trades([trade])
 
-    trade = _trade("T1", "EUR_USD", 1000, pips=7)
+    trade = _trade("T1", "EUR_USD", 1000, profit=0.6)
     closed = guard.process_open_trades([trade])
 
     assert closed == ["T1"]
     assert broker.closed == [{"trade_id": "T1", "instrument": "EUR_USD"}]
 
     out = capsys.readouterr().out
-    assert "[TRAIL] armed ticket=T1 profit_pips=10.00" in out
-    assert "[TRAIL] close ticket=T1 current_pips=7.00 floor=8.00 high_water=12.00 reason=TRAIL_GIVEBACK" in out
+    assert "[TRAIL] armed ticket=T1 profit_usd=0.80" in out
+    assert "[TRAIL] close ticket=T1 current_profit=0.60 floor=0.70 high_water=1.20 reason=usd_profit_protection" in out
 
 
 def test_multiple_positions_do_not_share_state():
     broker = DummyBroker()
-    guard = ProfitProtection(broker, arm_pips=5, giveback_pips=2, use_pips=True)
+    guard = ProfitProtection(broker, arm_usd=0.5, giveback_usd=0.25)
 
-    t1 = _trade("T1", "EUR_USD", 1000, pips=6)
-    t2 = _trade("T2", "EUR_USD", -1000, pips=3)
+    t1 = _trade("T1", "EUR_USD", 1000, profit=0.6)
+    t2 = _trade("T2", "EUR_USD", -1000, profit=0.3)
     guard.process_open_trades([t1, t2])
 
     # Only T1 should be armed and have a high-water update
     snap = guard.snapshot()
-    assert "T1" in snap and snap["T1"].high_water_pips == pytest.approx(6)
-    assert "T2" in snap and snap["T2"].high_water_pips == pytest.approx(3)
-    assert snap["T1"].trail_active is True
-    assert snap["T2"].trail_active is False
+    assert "T1" in snap and snap["T1"].max_profit_usd == pytest.approx(0.6)
+    assert "T2" in snap and snap["T2"].max_profit_usd == pytest.approx(0.3)
+    assert snap["T1"].armed is True
+    assert snap["T2"].armed is False
 
     # Drop T1 to trigger close while T2 climbs without being capped by T1's state
-    t1_drop = _trade("T1", "EUR_USD", 1000, pips=3)
-    t2_rise = _trade("T2", "EUR_USD", -1000, pips=6)
+    t1_drop = _trade("T1", "EUR_USD", 1000, profit=0.2)
+    t2_rise = _trade("T2", "EUR_USD", -1000, profit=0.6)
     closed = guard.process_open_trades([t1_drop, t2_rise])
 
     assert "T1" in closed
     assert "T2" not in closed
     assert any(entry.get("trade_id") == "T1" for entry in broker.closed)
     # T2 should retain its state
-    assert guard.snapshot()["T2"].high_water_pips == pytest.approx(6)
+    assert guard.snapshot()["T2"].max_profit_usd == pytest.approx(0.6)
 
 
 def test_daily_profit_cap_does_not_block_trailing(monkeypatch):
@@ -308,9 +313,9 @@ def test_demo_trailing_thresholds():
     live_guard = main_mod._profit_guard_for_mode("live", broker)
     paper_guard = main_mod._profit_guard_for_mode("paper", broker)
 
-    assert demo_guard.trigger == pytest.approx(1.0)
-    assert demo_guard.trail == pytest.approx(0.5)
-    assert live_guard.trigger == pytest.approx(3.0)
-    assert live_guard.trail == pytest.approx(0.5)
-    assert paper_guard.trigger == pytest.approx(3.0)
-    assert paper_guard.trail == pytest.approx(0.5)
+    assert demo_guard.trigger == pytest.approx(profit_protection.ARM_AT_USD)
+    assert demo_guard.trail == pytest.approx(profit_protection.GIVEBACK_USD)
+    assert live_guard.trigger == pytest.approx(profit_protection.ARM_AT_USD)
+    assert live_guard.trail == pytest.approx(profit_protection.GIVEBACK_USD)
+    assert paper_guard.trigger == pytest.approx(profit_protection.ARM_AT_USD)
+    assert paper_guard.trail == pytest.approx(profit_protection.GIVEBACK_USD)


### PR DESCRIPTION
## Summary
- switch trailing exit logic to track broker USD PnL with max_profit_usd/armed state and USD thresholds (ARM_AT_USD=0.75, GIVEBACK_USD=0.50)
- default configuration to USD-only guarding (use_pips disabled) and remove take-profit interference in decision flow
- update tests to validate USD protection behavior and no-TP order placement

## Testing
- pytest tests/test_profit_protection.py tests/test_decider.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953a73d7f848329a055dbc659eef078)