### PR TITLE
Clarify profit protection account-currency naming

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,16 +26,16 @@ SUMMARY_INTERVAL = max(1, int(settings.METRIC_SUMMARY_INTERVAL))
 
 trail_arm_pips = float(os.getenv("TRAIL_ARM_PIPS", "0.0"))
 trail_giveback_pips = float(os.getenv("TRAIL_GIVEBACK_PIPS", "0.0"))
-trail_arm_usd = float(os.getenv("TRAIL_ARM_USD", "0.75"))
-trail_giveback_usd = float(os.getenv("TRAIL_GIVEBACK_USD", "0.5"))
+trail_arm_ccy = float(os.getenv("TRAIL_ARM_CCY", os.getenv("TRAIL_ARM_USD", "0.75")))
+trail_giveback_ccy = float(os.getenv("TRAIL_GIVEBACK_CCY", os.getenv("TRAIL_GIVEBACK_USD", "0.5")))
 be_arm_pips = float(os.getenv("BE_ARM_PIPS", "6.0"))
 be_offset_pips = float(os.getenv("BE_OFFSET_PIPS", "1.0"))
 min_check_interval_sec = float(os.getenv("TRAIL_MIN_CHECK_INTERVAL", "0.0"))
 trailing_config = {
     "arm_pips": trail_arm_pips,
     "giveback_pips": trail_giveback_pips,
-    "arm_usd": trail_arm_usd,
-    "giveback_usd": trail_giveback_usd,
+    "arm_ccy": trail_arm_ccy,
+    "giveback_ccy": trail_giveback_ccy,
     "use_pips": False,
     "be_arm_pips": be_arm_pips,
     "be_offset_pips": be_offset_pips,

--- a/config/defaults.json
+++ b/config/defaults.json
@@ -69,8 +69,8 @@
   "trailing": {
     "arm_pips": 0.0,
     "giveback_pips": 0.0,
-    "arm_usd": 0.75,
-    "giveback_usd": 0.5,
+    "arm_ccy": 0.75,
+    "giveback_ccy": 0.5,
     "use_pips": false,
     "be_arm_pips": 0.0,
     "be_offset_pips": 0.0,

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -12,7 +12,7 @@ The trailing exit is controlled via environment variables (all optional):
 
 - `TRAIL_ARM_PIPS` (default `8`) — pips at which trailing activates.
 - `TRAIL_GIVEBACK_PIPS` (default `4`) — pips given back from the high-water before closing.
-- `TRAIL_ARM_USD` / `TRAIL_GIVEBACK_USD` — USD fallback thresholds when pip math is unavailable.
+- `TRAIL_ARM_CCY` / `TRAIL_GIVEBACK_CCY` — account-currency fallback thresholds when pip math is unavailable (legacy `TRAIL_ARM_USD` / `TRAIL_GIVEBACK_USD` are still honored).
 - `TRAIL_USE_PIPS` (default `true`) — prefer pip-based trailing when possible.
 - `BE_ARM_PIPS` (default `6`) and `BE_OFFSET_PIPS` (default `1`) — break-even guard once in profit.
 - `MIN_CHECK_INTERVAL_SEC` (default `0`) — optional rate-limit for trailing checks.

--- a/src/main.py
+++ b/src/main.py
@@ -159,22 +159,37 @@ risk_tf_minutes = _granularity_minutes(config["timeframe"])
 risk_cooldown_candles = int(os.getenv("COOLDOWN_CANDLES", config.get("cooldown_candles", 9)))
 risk_config = config.get("risk", {}) or {}
 aggressive_max_hold_minutes = float(os.getenv("AGGRESSIVE_MAX_HOLD_MINUTES", config.get("aggressive_max_hold_minutes", 45)))
-aggressive_max_loss_usd = float(os.getenv("AGGRESSIVE_MAX_LOSS_USD", config.get("aggressive_max_loss_usd", 5.0)))
+aggressive_max_loss_ccy = float(
+    os.getenv(
+        "AGGRESSIVE_MAX_LOSS_CCY",
+        os.getenv("AGGRESSIVE_MAX_LOSS_USD", config.get("aggressive_max_loss_ccy", config.get("aggressive_max_loss_usd", 5.0))),
+    )
+)
 aggressive_max_loss_atr_mult = float(os.getenv("AGGRESSIVE_MAX_LOSS_ATR_MULT", config.get("aggressive_max_loss_atr_mult", 1.2)))
 trailing_config = config.get("trailing", {}) or {}
 trail_use_pips = False
 trail_arm_pips = float(os.getenv("TRAIL_ARM_PIPS", trailing_config.get("arm_pips", 0.0)))
 trail_giveback_pips = float(os.getenv("TRAIL_GIVEBACK_PIPS", trailing_config.get("giveback_pips", 0.0)))
-trail_arm_usd = float(os.getenv("TRAIL_ARM_USD", trailing_config.get("arm_usd", 0.75)))
-trail_giveback_usd = float(os.getenv("TRAIL_GIVEBACK_USD", trailing_config.get("giveback_usd", 0.5)))
+trail_arm_ccy = float(
+    os.getenv(
+        "TRAIL_ARM_CCY",
+        os.getenv("TRAIL_ARM_USD", trailing_config.get("arm_ccy", trailing_config.get("arm_usd", 0.75))),
+    )
+)
+trail_giveback_ccy = float(
+    os.getenv(
+        "TRAIL_GIVEBACK_CCY",
+        os.getenv("TRAIL_GIVEBACK_USD", trailing_config.get("giveback_ccy", trailing_config.get("giveback_usd", 0.5))),
+    )
+)
 be_arm_pips = float(os.getenv("BE_ARM_PIPS", trailing_config.get("be_arm_pips", 0.0)))
 be_offset_pips = float(os.getenv("BE_OFFSET_PIPS", trailing_config.get("be_offset_pips", 0.0)))
 min_check_interval_sec = float(os.getenv("MIN_CHECK_INTERVAL_SEC", trailing_config.get("min_check_interval_sec", 0.0)))
 trailing_config = {
     "arm_pips": trail_arm_pips,
     "giveback_pips": trail_giveback_pips,
-    "arm_usd": trail_arm_usd,
-    "giveback_usd": trail_giveback_usd,
+    "arm_ccy": trail_arm_ccy,
+    "giveback_ccy": trail_giveback_ccy,
     "use_pips": trail_use_pips,
     "be_arm_pips": be_arm_pips,
     "be_offset_pips": be_offset_pips,
@@ -228,7 +243,7 @@ config["max_open_trades"] = int(os.getenv("MAX_OPEN_TRADES", risk_config.get("ma
 risk_config["timeframe"] = config["timeframe"]
 config["aggressive_mode"] = aggressive_mode
 config["aggressive_max_hold_minutes"] = aggressive_max_hold_minutes
-config["aggressive_max_loss_usd"] = aggressive_max_loss_usd
+config["aggressive_max_loss_ccy"] = aggressive_max_loss_ccy
 config["aggressive_max_loss_atr_mult"] = aggressive_max_loss_atr_mult
 config["risk"] = risk_config
 
@@ -732,7 +747,7 @@ async def decision_cycle() -> None:
 
             atr_val = diagnostics.get("atr")
             sl_distance = risk.sl_distance_from_atr(atr_val, instrument=evaluation.instrument)
-            tp_distance = 0.0  # Disable standard TP to avoid interfering with USD-based profit protection
+            tp_distance = 0.0  # Disable standard TP to avoid interfering with account-currency profit protection
             entry_price = diagnostics.get("close")
 
             if not trend_ok:

--- a/src/risk_setup.py
+++ b/src/risk_setup.py
@@ -11,8 +11,8 @@ from src.risk_manager import RiskManager
 DEFAULT_TRAILING_CONFIG = {
     "arm_pips": 0.0,
     "giveback_pips": 0.0,
-    "arm_usd": 0.75,
-    "giveback_usd": 0.5,
+    "arm_ccy": 0.75,
+    "giveback_ccy": 0.5,
     "use_pips": False,
     "be_arm_pips": 0.0,
     "be_offset_pips": 0.0,
@@ -69,13 +69,15 @@ def build_profit_protection(
     ts_minutes = float(ts_cfg.get("minutes", DEFAULT_TIME_STOP["minutes"]))
     ts_min_pips = float(ts_cfg.get("min_pips", DEFAULT_TIME_STOP["min_pips"]))
     ts_xau_mult = float(ts_cfg.get("xau_atr_mult", DEFAULT_TIME_STOP["xau_atr_mult"]))
+    arm_ccy = trailing_cfg.get("arm_ccy", trailing_cfg.get("arm_usd"))
+    giveback_ccy = trailing_cfg.get("giveback_ccy", trailing_cfg.get("giveback_usd"))
 
     return ProfitProtection(
         broker,
-        trigger=trailing_cfg["arm_usd"],
-        trail=trailing_cfg["giveback_usd"],
-        arm_usd=trailing_cfg["arm_usd"],
-        giveback_usd=trailing_cfg["giveback_usd"],
+        trigger=float(arm_ccy if arm_ccy is not None else DEFAULT_TRAILING_CONFIG["arm_ccy"]),
+        trail=float(giveback_ccy if giveback_ccy is not None else DEFAULT_TRAILING_CONFIG["giveback_ccy"]),
+        arm_ccy=arm_ccy,
+        giveback_ccy=giveback_ccy,
         arm_pips=trailing_cfg["arm_pips"],
         giveback_pips=trailing_cfg["giveback_pips"],
         use_pips=False,
@@ -84,7 +86,9 @@ def build_profit_protection(
         min_check_interval_sec=trailing_cfg["min_check_interval_sec"],
         aggressive=aggressive,
         aggressive_max_hold_minutes=float(trailing_cfg.get("aggressive_max_hold_minutes", 45.0)),
-        aggressive_max_loss_usd=float(trailing_cfg.get("aggressive_max_loss_usd", 5.0)),
+        aggressive_max_loss_ccy=float(
+            trailing_cfg.get("aggressive_max_loss_ccy", trailing_cfg.get("aggressive_max_loss_usd", 5.0))
+        ),
         aggressive_max_loss_atr_mult=float(trailing_cfg.get("aggressive_max_loss_atr_mult", 1.2)),
         time_stop_minutes=ts_minutes,
         time_stop_min_pips=ts_min_pips,


### PR DESCRIPTION
## Summary
- rename profit-protection constants, state, and logging to account-currency (ccy) terminology while documenting broker PnL source
- update trailing configuration, environment fallbacks, and defaults to use ccy naming with backward-compatible legacy keys and refreshed deployment docs
- align profit protection tests with the ccy terminology and expectations

## Testing
- python -m pytest tests/test_profit_protection.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953b2bb24b88329ad0796ad80b3bde7)