### PR TITLE
Improve profit-protection handling for missing broker positions

### DIFF
--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -1,6 +1,7 @@
 """Profit-protection logic for trailing unrealized gains."""
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Dict, Iterable, List, Optional, Protocol
@@ -484,10 +485,17 @@ class ProfitProtection:
             return True
 
         error_code = self._extract_error_code(result)
+        closed_status = self._broker_confirms_closed(trade_id, instrument)
         if error_code == "CLOSEOUT_POSITION_DOESNT_EXIST":
-            if self._broker_confirms_closed(trade_id, instrument):
+            if closed_status is True:
                 print(
                     f"{log_prefix}[INFO] Trade already closed at broker; marking closed ticket={trade_id} instrument={instrument}{spread_clause}",
+                    flush=True,
+                )
+                return True
+            if closed_status is None and self._response_indicates_missing_position(result):
+                print(
+                    f"{log_prefix}[INFO] Broker response indicates no open position; marking closed ticket={trade_id} instrument={instrument}{spread_clause}",
                     flush=True,
                 )
                 return True
@@ -499,7 +507,7 @@ class ProfitProtection:
             # If the broker did not acknowledge the close, perform a follow-up check
             # to see whether the position already disappeared (e.g., previously closed
             # or closed by another rule). Only then can we safely treat it as closed.
-            if self._broker_confirms_closed(trade_id, instrument):
+            if closed_status is True:
                 print(
                     f"{log_prefix}[WARN] Close response inconclusive but {instrument} is no longer open; marking closed",
                     flush=True,
@@ -536,19 +544,58 @@ class ProfitProtection:
                 return None
         return None
 
-    def _broker_confirms_closed(self, trade_id: Optional[str], instrument: str) -> bool:
-        """Return True only if broker reports no open position for the instrument."""
+    def _response_indicates_missing_position(self, result: Dict) -> bool:
+        """Return True when the broker response clearly states no position exists."""
+
+        if not isinstance(result, dict):
+            return False
+
+        payload = None
+        text = result.get("text")
+        if isinstance(text, str):
+            try:
+                payload = json.loads(text)
+            except Exception:
+                if "CLOSEOUT_POSITION_DOESNT_EXIST" in text:
+                    return True
+
+        payload = payload or result
+
+        for key in ("errorCode", "error_code"):
+            code = payload.get(key)
+            if isinstance(code, str) and code == "CLOSEOUT_POSITION_DOESNT_EXIST":
+                return True
+
+        for leg in ("longOrderRejectTransaction", "shortOrderRejectTransaction"):
+            reject_reason = (payload.get(leg) or {}).get("rejectReason")
+            if isinstance(reject_reason, str) and "CLOSEOUT_POSITION_DOESNT_EXIST" in reject_reason:
+                return True
+
+        message = payload.get("errorMessage")
+        if isinstance(message, str) and "does not exist" in message:
+            return True
+
+        return False
+
+    def _broker_confirms_closed(self, trade_id: Optional[str], instrument: str) -> Optional[bool]:
+        """Return True only if broker reports no open position for the instrument.
+
+        Returns False when the instrument is still present. Returns None when the broker
+        cannot confirm (missing capability or transient failure).
+        """
 
         try:
             if not hasattr(self.broker, "list_open_trades"):
-                return False
+                return None
             trades = self.broker.list_open_trades()
+            if trades is None:
+                return None
         except Exception as exc:  # pragma: no cover - defensive logging
             print(
                 f"[TRAIL][WARN] Unable to confirm closure for {instrument}: {exc}",
                 flush=True,
             )
-            return False
+            return None
 
         for trade in trades or []:
             inst = trade.get("instrument")

--- a/tests/test_profit_protection.py
+++ b/tests/test_profit_protection.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import json
 from pathlib import Path
 import sys
 
@@ -163,6 +164,39 @@ def test_closeout_missing_warns_when_position_still_open(capsys):
     assert closed == []
     out = capsys.readouterr().out
     assert "[TRAIL][WARN] Broker reported CLOSEOUT_POSITION_DOESNT_EXIST but GBP_USD still appears open" in out
+
+
+def test_payload_with_missing_position_marks_closed(capsys):
+    class PayloadBroker(DummyBroker):
+        def __init__(self):
+            super().__init__()
+            self.trades = [{"id": "T-PAY", "instrument": "EUR_USD"}]
+
+        def close_trade(self, trade_id: str, instrument: str | None = None):
+            payload = {
+                "longOrderRejectTransaction": {
+                    "rejectReason": "CLOSEOUT_POSITION_DOESNT_EXIST",
+                    "instrument": instrument,
+                },
+                "errorCode": "CLOSEOUT_POSITION_DOESNT_EXIST",
+                "errorMessage": "The Position requested to be closed out does not exist",
+            }
+            return {"status": "ERROR", "code": 400, "text": json.dumps(payload)}
+
+    broker = PayloadBroker()
+    guard = ProfitProtection(broker, arm_ccy=0.5, giveback_ccy=0.25)
+
+    armed = _trade("T-PAY", "EUR_USD", 1000, profit=0.8)
+    guard.process_open_trades([armed])
+    drop = _trade("T-PAY", "EUR_USD", 1000, profit=0.2)
+    closed = guard.process_open_trades([drop])
+
+    assert closed == ["T-PAY"]
+    out = capsys.readouterr().out
+    assert (
+        "[TRAIL][INFO] Broker response indicates no open position; marking closed ticket=T-PAY instrument=EUR_USD"
+        in out
+    )
 
 
 def test_daily_profit_cap_does_not_block_trailing(monkeypatch):


### PR DESCRIPTION
## Summary
- add parsing for broker closeout responses that explicitly indicate missing positions
- allow profit protection to mark trades closed when confirmation is unavailable but payload shows the position is gone
- extend profit protection tests to cover the new closeout payload path

## Testing
- python -m pytest tests/test_profit_protection.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953c81890008329b895fef97ac231cd)