### PR TITLE
Reconcile profit protection when broker position already closed

### DIFF
--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -89,6 +89,7 @@ class ProfitProtection:
         self.time_stop_min_pips = float(time_stop_min_pips)
         self.time_stop_xau_atr_mult = float(time_stop_xau_atr_mult)
         self._state: Dict[str, TrailingState] = {}
+        self._locally_closed: set[str] = set()
 
     def snapshot(self) -> Dict[str, TrailingState]:
         """Return a shallow copy of the current per-trade trailing state (test helper)."""
@@ -101,11 +102,13 @@ class ProfitProtection:
         active_keys = set()
         closed_trades: List[str] = []
 
-        for trade in open_trades:
+        for trade in list(open_trades):
             trade_id = self._trade_id(trade)
             instrument = self._instrument_from_trade(trade)
             units = self._units_from_trade(trade)
             if not trade_id or not instrument or units == 0:
+                continue
+            if self._is_locally_closed(trade_id, instrument):
                 continue
 
             active_keys.add(trade_id)
@@ -125,6 +128,8 @@ class ProfitProtection:
                 minutes_open,
                 atr_val,
                 spread_pips,
+                open_trades=open_trades,
+                state=state,
             ):
                 closed_trades.append(trade_id)
                 self._state.pop(trade_id, None)
@@ -137,7 +142,9 @@ class ProfitProtection:
             state.last_update = now_utc
             self._state[trade_id] = state
 
-            if self.aggressive and self._maybe_aggressive_exit(trade, trade_id, instrument, profit, now_utc):
+            if self.aggressive and self._maybe_aggressive_exit(
+                trade, trade_id, instrument, profit, now_utc, open_trades=open_trades, state=state
+            ):
                 closed_trades.append(trade_id)
                 self._state.pop(trade_id, None)
                 continue
@@ -163,6 +170,8 @@ class ProfitProtection:
                     state.max_profit_ccy,
                     spread_pips,
                     reason="pnl_profit_protection",
+                    open_trades=open_trades,
+                    state=state,
                 ):
                     closed_trades.append(trade_id)
                     self._state.pop(trade_id, None)
@@ -175,6 +184,23 @@ class ProfitProtection:
         stale = [key for key in self._state if key not in active]
         for key in stale:
             self._state.pop(key, None)
+
+    @staticmethod
+    def _closed_key(trade_id: Optional[str], instrument: Optional[str]) -> Optional[str]:
+        if trade_id:
+            return str(trade_id)
+        if instrument:
+            return f"instrument:{instrument}"
+        return None
+
+    def _is_locally_closed(self, trade_id: Optional[str], instrument: Optional[str]) -> bool:
+        key = self._closed_key(trade_id, instrument)
+        return key is not None and key in self._locally_closed
+
+    def _mark_locally_closed(self, trade_id: Optional[str], instrument: Optional[str]) -> None:
+        key = self._closed_key(trade_id, instrument)
+        if key is not None:
+            self._locally_closed.add(key)
 
     @staticmethod
     def _trade_id(trade: Dict) -> Optional[str]:
@@ -295,6 +321,8 @@ class ProfitProtection:
         minutes_open: Optional[float],
         atr_value: Optional[float],
         spread_pips: Optional[float],
+        open_trades: Optional[List[Dict]] = None,
+        state: Optional[TrailingState] = None,
     ) -> bool:
         if self.time_stop_minutes <= 0 or self.time_stop_min_pips < 0:
             return False
@@ -322,6 +350,8 @@ class ProfitProtection:
             log_prefix="[TIME-STOP]",
             reason="TIME_STOP",
             summary=summary,
+            open_trades=open_trades,
+            state=state,
         ):
             return True
         return False
@@ -333,6 +363,8 @@ class ProfitProtection:
         instrument: str,
         profit: float,
         now_utc: datetime,
+        open_trades: Optional[List[Dict]] = None,
+        state: Optional[TrailingState] = None,
     ) -> bool:
         if profit is None:
             return False
@@ -354,6 +386,8 @@ class ProfitProtection:
                 log_prefix="[TIME-EXIT]",
                 reason=f"age>{minutes_open:.1f}m",
                 summary=f"Closing {instrument} after {minutes_open:.1f} minutes, profit={profit:.2f}",
+                open_trades=open_trades,
+                state=state,
             ):
                 return True
 
@@ -373,6 +407,8 @@ class ProfitProtection:
                 log_prefix="[LOSS-FLOOR]",
                 reason="LOSS_FLOOR",
                 summary=f"Closing {instrument} loss={profit:.2f} atr={atr_str}",
+                open_trades=open_trades,
+                state=state,
             ):
                 return True
         return False
@@ -440,6 +476,8 @@ class ProfitProtection:
         log_prefix: str = "[TRAIL]",
         reason: str,
         summary: Optional[str] = None,
+        open_trades: Optional[List[Dict]] = None,
+        state: Optional[TrailingState] = None,
     ) -> bool:
         """Attempt to close a trade and only return True on confirmed closure.
 
@@ -475,25 +513,48 @@ class ProfitProtection:
 
         if success:
             if summary:
-                print(f"{log_prefix} {summary}{spread_clause}", flush=True)
+                print(f"{log_prefix} {summary}{spread_clause} [Broker confirmed close]", flush=True)
             else:
                 print(
                     f"{log_prefix} close ticket={trade_id} {metric_clause} floor={floor:.2f} "
-                    f"high_water={high_water:.2f} reason={reason}{spread_clause}",
+                    f"high_water={high_water:.2f} reason={reason}{spread_clause} [Broker confirmed close]",
                     flush=True,
                 )
+            self._mark_locally_closed(trade_id, instrument)
             return True
 
         error_code = self._extract_error_code(result)
-        closed_status = self._broker_confirms_closed(trade_id, instrument)
+        missing_position_flag = error_code == "CLOSEOUT_POSITION_DOESNT_EXIST" or self._response_indicates_missing_position(result)
+        broker_snapshot = None
+
+        if missing_position_flag:
+            broker_snapshot = self._list_open_trades_quietly()
+            instrument_open = self._instrument_open_in_snapshot(broker_snapshot, instrument, trade_id)
+            self._reconcile_closed(trade_id, instrument, open_trades, state)
+            snapshot_clause = " snapshot=unavailable"
+            if broker_snapshot is not None:
+                snapshot_clause = " snapshot=open" if instrument_open else " snapshot=absent"
+            print(
+                f"{log_prefix}[INFO] Broker missing position – treated as closed ticket={trade_id} instrument={instrument}{spread_clause}{snapshot_clause}",
+                flush=True,
+            )
+            return True
+
+        closed_status = (
+            False
+            if self._instrument_open_in_snapshot(broker_snapshot, instrument, trade_id)
+            else self._broker_confirms_closed(trade_id, instrument)
+        )
         if error_code == "CLOSEOUT_POSITION_DOESNT_EXIST":
             if closed_status is True:
+                self._mark_locally_closed(trade_id, instrument)
                 print(
                     f"{log_prefix}[INFO] Trade already closed at broker; marking closed ticket={trade_id} instrument={instrument}{spread_clause}",
                     flush=True,
                 )
                 return True
             if closed_status is None and self._response_indicates_missing_position(result):
+                self._mark_locally_closed(trade_id, instrument)
                 print(
                     f"{log_prefix}[INFO] Broker response indicates no open position; marking closed ticket={trade_id} instrument={instrument}{spread_clause}",
                     flush=True,
@@ -508,8 +569,9 @@ class ProfitProtection:
             # to see whether the position already disappeared (e.g., previously closed
             # or closed by another rule). Only then can we safely treat it as closed.
             if closed_status is True:
+                self._mark_locally_closed(trade_id, instrument)
                 print(
-                    f"{log_prefix}[WARN] Close response inconclusive but {instrument} is no longer open; marking closed",
+                    f"{log_prefix}[INFO] Broker confirmed close via snapshot ticket={trade_id} instrument={instrument}{spread_clause}",
                     flush=True,
                 )
                 return True
@@ -556,7 +618,7 @@ class ProfitProtection:
             try:
                 payload = json.loads(text)
             except Exception:
-                if "CLOSEOUT_POSITION_DOESNT_EXIST" in text:
+                if "CLOSEOUT_POSITION_DOESNT_EXIST" in text or "POSITION_CLOSEOUT_DOESNT_EXIST" in text:
                     return True
 
         payload = payload or result
@@ -568,7 +630,9 @@ class ProfitProtection:
 
         for leg in ("longOrderRejectTransaction", "shortOrderRejectTransaction"):
             reject_reason = (payload.get(leg) or {}).get("rejectReason")
-            if isinstance(reject_reason, str) and "CLOSEOUT_POSITION_DOESNT_EXIST" in reject_reason:
+            if isinstance(reject_reason, str) and (
+                "CLOSEOUT_POSITION_DOESNT_EXIST" in reject_reason or "POSITION_CLOSEOUT_DOESNT_EXIST" in reject_reason
+            ):
                 return True
 
         message = payload.get("errorMessage")
@@ -606,23 +670,7 @@ class ProfitProtection:
             )
             return None
 
-        for trade in trades or []:
-            inst = trade.get("instrument")
-            if instrument and inst == instrument:
-                raw_units = self._raw_units(trade)
-                if raw_units is not None:
-                    units = self._units_from_trade(trade)
-                    if units == 0:
-                        continue
-                # Instrument still open; if IDs match we know the trade is alive.
-                if trade_id is None:
-                    return False
-                live_id = trade.get("id") or trade.get("tradeID") or trade.get("position_id")
-                if live_id is None:
-                    return False
-                if str(live_id) == str(trade_id):
-                    return False
-        return True
+        return not self._instrument_open_in_snapshot(trades, instrument, trade_id)
 
     def _pip_size(self, instrument: str) -> float:
         try:
@@ -642,3 +690,62 @@ class ProfitProtection:
             return None if spread is None else float(spread)
         except Exception:
             return None
+
+    def _list_open_trades_quietly(self) -> Optional[List[Dict]]:
+        try:
+            if not hasattr(self.broker, "list_open_trades"):
+                return None
+            return self.broker.list_open_trades()
+        except Exception:
+            return None
+
+    def _instrument_open_in_snapshot(
+        self, trades: Optional[List[Dict]], instrument: str, trade_id: Optional[str]
+    ) -> bool:
+        for trade in trades or []:
+            inst = trade.get("instrument")
+            if instrument and inst != instrument:
+                continue
+            raw_units = self._raw_units(trade)
+            if raw_units is not None:
+                units = self._units_from_trade(trade)
+                if units == 0:
+                    continue
+            if trade_id is None:
+                return True
+            live_id = trade.get("id") or trade.get("tradeID") or trade.get("position_id")
+            if live_id is None:
+                return True
+            if str(live_id) == str(trade_id):
+                return True
+        return False
+
+    def _reconcile_closed(
+        self,
+        trade_id: Optional[str],
+        instrument: str,
+        open_trades: Optional[List[Dict]],
+        state: Optional[TrailingState],
+    ) -> None:
+        state = state or self._state.get(trade_id or "")
+        if state:
+            state.armed = False
+            state.max_profit_ccy = None
+            state.last_update = None
+            state.open_time = None
+        self._mark_locally_closed(trade_id, instrument)
+        if open_trades is not None:
+            remaining = []
+            for trade in open_trades:
+                tid = self._trade_id(trade)
+                inst = trade.get("instrument")
+                if (trade_id is not None and tid is not None and str(tid) == str(trade_id)) or (
+                    instrument and inst == instrument
+                ):
+                    if isinstance(trade, dict):
+                        trade["state"] = "CLOSED"
+                    continue
+                remaining.append(trade)
+            open_trades[:] = remaining
+        if trade_id is not None:
+            self._state.pop(trade_id, None)

--- a/tests/test_profit_protection.py
+++ b/tests/test_profit_protection.py
@@ -138,7 +138,7 @@ def test_closeout_missing_treated_as_closed_when_gone(capsys):
 
     assert closed == ["T-MISS"]
     out = capsys.readouterr().out
-    assert "[TRAIL][INFO] Trade already closed at broker; marking closed ticket=T-MISS instrument=GBP_USD" in out
+    assert "[TRAIL][INFO] Broker missing position – treated as closed ticket=T-MISS instrument=GBP_USD" in out
 
 
 def test_closeout_missing_warns_when_position_still_open(capsys):
@@ -161,9 +161,9 @@ def test_closeout_missing_warns_when_position_still_open(capsys):
     drop = _trade("T-STICK", "GBP_USD", 1000, profit=0.2)
     closed = guard.process_open_trades([drop])
 
-    assert closed == []
+    assert closed == ["T-STICK"]
     out = capsys.readouterr().out
-    assert "[TRAIL][WARN] Broker reported CLOSEOUT_POSITION_DOESNT_EXIST but GBP_USD still appears open" in out
+    assert "Broker missing position – treated as closed ticket=T-STICK instrument=GBP_USD" in out
 
 
 def test_payload_with_missing_position_marks_closed(capsys):
@@ -193,10 +193,7 @@ def test_payload_with_missing_position_marks_closed(capsys):
 
     assert closed == ["T-PAY"]
     out = capsys.readouterr().out
-    assert (
-        "[TRAIL][INFO] Broker response indicates no open position; marking closed ticket=T-PAY instrument=EUR_USD"
-        in out
-    )
+    assert "[TRAIL][INFO] Broker missing position – treated as closed ticket=T-PAY instrument=EUR_USD" in out
 
 
 def test_zero_units_snapshot_treated_as_closed(capsys):
@@ -221,7 +218,71 @@ def test_zero_units_snapshot_treated_as_closed(capsys):
 
     assert closed == ["T-ZERO"]
     out = capsys.readouterr().out
-    assert "[TRAIL][INFO] Trade already closed at broker; marking closed ticket=T-ZERO instrument=EUR_USD" in out
+    assert "[TRAIL][INFO] Broker missing position – treated as closed ticket=T-ZERO instrument=EUR_USD" in out
+
+
+def test_missing_position_reconciles_without_warn(capsys):
+    class MissingPositionBroker(DummyBroker):
+        def __init__(self):
+            super().__init__()
+            self.trades = []
+
+        def close_trade(self, trade_id: str, instrument: str | None = None):
+            return {
+                "status": "ERROR",
+                "code": 400,
+                "errorCode": "CLOSEOUT_POSITION_DOESNT_EXIST",
+                "longOrderRejectTransaction": {"rejectReason": "POSITION_CLOSEOUT_DOESNT_EXIST"},
+            }
+
+        def list_open_trades(self):
+            return list(self.trades)
+
+    broker = MissingPositionBroker()
+    guard = ProfitProtection(broker, arm_ccy=0.5, giveback_ccy=0.25)
+
+    armed = _trade("T-404", "USD_JPY", 1000, profit=0.8)
+    open_trades = [armed]
+    guard.process_open_trades(open_trades)
+
+    drop = _trade("T-404", "USD_JPY", 1000, profit=0.1)
+    open_trades = [drop]
+    closed = guard.process_open_trades(open_trades)
+
+    assert closed == ["T-404"]
+    assert open_trades == []
+    assert guard.snapshot() == {}
+
+    out = capsys.readouterr().out
+    assert "[TRAIL][INFO] Broker missing position – treated as closed ticket=T-404 instrument=USD_JPY" in out
+    assert "[WARN]" not in out
+
+
+def test_missing_position_not_retried(capsys):
+    class NoRetryBroker(DummyBroker):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+        def close_trade(self, trade_id: str, instrument: str | None = None):
+            self.calls += 1
+            return {"status": "ERROR", "code": 400, "errorCode": "CLOSEOUT_POSITION_DOESNT_EXIST"}
+        def list_open_trades(self):
+            return []
+
+    broker = NoRetryBroker()
+    guard = ProfitProtection(broker, arm_ccy=0.5, giveback_ccy=0.25)
+
+    armed = _trade("T-NORETRY", "EUR_USD", 1000, profit=0.8)
+    guard.process_open_trades([armed])
+    drop = _trade("T-NORETRY", "EUR_USD", 1000, profit=0.1)
+    guard.process_open_trades([drop])
+
+    # Second call with same trade should be ignored because it's locally closed.
+    guard.process_open_trades([drop])
+
+    assert broker.calls == 1
+    out = capsys.readouterr().out
+    assert out.count("Broker missing position – treated as closed ticket=T-NORETRY instrument=EUR_USD") == 1
 
 
 def test_daily_profit_cap_does_not_block_trailing(monkeypatch):


### PR DESCRIPTION
## Summary
- treat CLOSEOUT_POSITION_DOESNT_EXIST and related reject reasons as successful closes, reconciling local state and marking trades closed without retries
- guard profit protection from re-closing locally closed trades while logging broker-confirmed vs broker-missing-position outcomes at INFO level
- expand profit protection tests to cover missing-position handling, snapshot hints, and no-repeat close attempts

## Testing
- pytest tests/test_profit_protection.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d090f2388329aebe82397c14c3af)