### PR TITLE
Fix uninitialized long_units in close trade execution

### DIFF
--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -554,8 +554,6 @@ class ProfitProtection:
             self._reconcile_closed(trade_id, instrument, open_trades, state)
             return True
 
-        result = self._execute_closeout(trade_id, instrument, long_units, short_units)
-
         spread_clause = f" spread={spread_pips:.2f}" if spread_pips is not None else ""
         if pips is not None:
             metric_clause = f"current_pips={pips:.2f}"


### PR DESCRIPTION
## Summary
- prevent `_close_trade` from calling the broker with undefined `long_units`/`short_units`
- keep closeout attempts based on the detected position snapshot to avoid runtime failures

## Testing
- python -m compileall src/profit_protection.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954095a07a88329b189ac1d87b1804d)