### PR TITLE
Fix uninitialized long_units in close trade execution

### DIFF
--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -554,8 +554,6 @@ class ProfitProtection:
             self._reconcile_closed(trade_id, instrument, open_trades, state)
             return True
 
-        result = self._execute_closeout(trade_id, instrument, long_units, short_units)
-
         spread_clause = f" spread={spread_pips:.2f}" if spread_pips is not None else ""
         if pips is not None:
             metric_clause = f"current_pips={pips:.2f}"

--- a/tests/test_profit_protection.py
+++ b/tests/test_profit_protection.py
@@ -107,6 +107,30 @@ def _trade(trade_id: str, instrument: str, units: float, profit: float | None = 
     return payload
 
 
+def test_close_trade_handles_missing_snapshot_without_units():
+    broker = DummyBroker()
+    guard = ProfitProtection(broker)
+
+    result = guard._close_trade(  # noqa: SLF001
+        "T-no-snapshot",
+        "EUR_USD",
+        profit=0.0,
+        pips=None,
+        floor=0.0,
+        high_water=0.0,
+        spread_pips=None,
+        log_prefix="[TEST]",
+        reason="MISSING_SNAPSHOT",
+        summary=None,
+        open_trades=None,
+        state=None,
+        units=None,
+    )
+
+    assert result is True
+    assert broker.closed[-1]["payload"] == {"longUnits": "0", "shortUnits": "0"}
+
+
 def test_trailing_giveback_closes_at_floor(capsys):
     broker = DummyBroker(profits={"EUR_USD": [0.0, 0.8, 1.2, 0.6]})
     guard = ProfitProtection(


### PR DESCRIPTION
## Summary
- prevent `_close_trade` from calling the broker with undefined `long_units`/`short_units`
- add regression coverage ensuring closeouts succeed even when position snapshots are missing

## Testing
- python -m compileall src/profit_protection.py
- pytest tests/test_profit_protection.py -k missing_snapshot

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954095a07a88329b189ac1d87b1804d)