### PR TITLE
Add trade summary logging and soft scalp mode

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -74,7 +74,8 @@
     "use_pips": false,
     "be_arm_pips": 0.0,
     "be_offset_pips": 0.0,
-    "min_check_interval_sec": 0.0
+    "min_check_interval_sec": 0.0,
+    "soft_scalp_mode": false
   },
   "time_stop": {
     "minutes": 90,

--- a/src/risk_setup.py
+++ b/src/risk_setup.py
@@ -17,6 +17,7 @@ DEFAULT_TRAILING_CONFIG = {
     "be_arm_pips": 0.0,
     "be_offset_pips": 0.0,
     "min_check_interval_sec": 0.0,
+    "soft_scalp_mode": False,
 }
 
 DEFAULT_TIME_STOP = {
@@ -93,4 +94,5 @@ def build_profit_protection(
         time_stop_minutes=ts_minutes,
         time_stop_min_pips=ts_min_pips,
         time_stop_xau_atr_mult=ts_xau_mult,
+        soft_scalp_mode=bool(trailing_cfg.get("soft_scalp_mode", False)),
     )


### PR DESCRIPTION
## Summary
- add one-time trade summary logging with high-water, final profit, duration, and closed-by details when trades reconcile closed
- add optional SOFT_SCALP_MODE flag (env/config) to allow giveback exits without arming for scalps while preserving default behavior otherwise
- expand profit protection tests to cover summary emission, soft scalp mode, and missing-position reconciliation

## Testing
- python -m py_compile src/profit_protection.py
- pytest tests/test_profit_protection.py -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69549f6470a08329a3132a383c0bffbe)