### PR TITLE
Improve trailing configuration handling

### DIFF
--- a/tests/test_main_trailing_config.py
+++ b/tests/test_main_trailing_config.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import src.main as main_mod
+
+
+def test_trailing_config_prefers_min_check_override(monkeypatch):
+    config: Dict = {"trailing": {"min_check_interval_sec": 5.0}}
+    monkeypatch.setenv("TRAIL_MIN_CHECK_INTERVAL", "12")
+    monkeypatch.setenv("MIN_CHECK_INTERVAL_SEC", "7")
+
+    trailing = main_mod._build_trailing_config(config)
+
+    assert trailing["min_check_interval_sec"] == 7.0
+
+
+def test_trailing_config_soft_scalp_from_env(monkeypatch):
+    config: Dict = {"trailing": {"soft_scalp_mode": False}}
+    monkeypatch.setenv("SOFT_SCALP_MODE", "true")
+
+    trailing = main_mod._build_trailing_config(config)
+
+    assert trailing["soft_scalp_mode"] is True
+
+
+def test_trailing_config_soft_scalp_from_config(monkeypatch):
+    config: Dict = {"trailing": {"soft_scalp_mode": True}}
+    monkeypatch.delenv("SOFT_SCALP_MODE", raising=False)
+
+    trailing = main_mod._build_trailing_config(config)
+
+    assert trailing["soft_scalp_mode"] is True


### PR DESCRIPTION
## Summary
- centralize trailing configuration parsing with clearer env fallbacks
- add soft scalp mode handling and min-check override precedence to config builder
- add tests covering trailing configuration behaviors

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6954a87065d48329939fe31b0e383bd3)