### PR TITLE
Handle balance adjustments in risk metrics

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -64,7 +64,11 @@
       "start": "04:55",
       "end": "05:05"
     },
-    "max_trades_per_day": 50
+    "max_trades_per_day": 50,
+    "equity_adjustment_pct": 0.05,
+    "equity_adjustment_abs": 20.0,
+    "EQUITY_ADJUSTMENT_PCT": 0.05,
+    "EQUITY_ADJUSTMENT_ABS": 20.0
   },
   "trailing": {
     "arm_pips": 0.0,

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -146,6 +146,63 @@ def test_demo_profit_cap_blocks_and_resets_next_day(state_dir, capsys):
     assert manager.state.daily_profit_cap_hit is False
 
 
+def test_balance_adjustment_shifts_baselines(state_dir, capsys):
+    manager = RiskManager(
+        {
+            "equity_adjustment_pct": 0.05,
+            "equity_adjustment_abs": 20.0,
+            "daily_profit_target_usd": 5.0,
+        },
+        mode="paper",
+        demo_mode=True,
+    )
+    now = _utc(2024, 1, 1, 0, 0)
+
+    ok, reason = manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    assert ok is True
+    assert reason == "ok"
+    pre_adjust_daily_pl = 1_000.0 - manager.state.day_start_equity
+    capsys.readouterr()
+
+    adjusted_now = now + timedelta(hours=1)
+    ok, reason = manager.should_open(adjusted_now, 1_060.0, [], "EUR_USD", 0.2)
+    log = capsys.readouterr().out
+
+    assert ok is True
+    assert reason == "ok"
+    assert "[EQUITY-ADJUST][WARN]" in log
+    assert manager.state.day_start_equity == pytest.approx(1_060.0)
+    assert manager.state.day_start_equity_utc == pytest.approx(1_060.0)
+    assert manager.state.week_start_equity == pytest.approx(1_060.0)
+    assert manager.state.daily_profit_cap_hit is False
+    post_adjust_daily_pl = 1_060.0 - manager.state.day_start_equity
+    assert pre_adjust_daily_pl == pytest.approx(post_adjust_daily_pl)
+
+
+def test_balance_adjustment_skips_when_positions_open(state_dir):
+    manager = RiskManager(
+        {
+            "equity_adjustment_pct": 0.05,
+            "equity_adjustment_abs": 20.0,
+        },
+        mode="paper",
+    )
+    now = _utc(2024, 1, 1, 0, 0)
+
+    ok, reason = manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    assert ok is True
+    assert reason == "ok"
+
+    open_positions = [{"instrument": "EUR_USD"}]
+    later = now + timedelta(minutes=30)
+    ok, reason = manager.should_open(later, 1_100.0, open_positions, "EUR_USD", 0.2)
+
+    assert ok is True
+    assert reason == "ok"
+    assert manager.state.day_start_equity == pytest.approx(1_000.0)
+    assert manager.state.week_start_equity == pytest.approx(1_000.0)
+
+
 def test_rollover_window_blocks(state_dir):
     manager = RiskManager(
         {


### PR DESCRIPTION
## Summary
- allow equity adjustment thresholds to be configured with uppercase or lowercase keys while keeping defaults in the risk config
- log detected balance adjustments with warnings, clamp drawdown calculations, and keep baselines aligned when shifting for deposits/withdrawals
- extend risk manager tests to confirm baseline shifts preserve daily P/L and adjustments are ignored when positions are open

## Testing
- PYTHONPATH=. pytest tests/test_risk_manager.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564aacff048329b4919319faa3291c)