### PR TITLE
Handle balance adjustments in risk metrics

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -64,7 +64,11 @@
       "start": "04:55",
       "end": "05:05"
     },
-    "max_trades_per_day": 50
+    "max_trades_per_day": 50,
+    "equity_adjustment_pct": 0.05,
+    "equity_adjustment_abs": 20.0,
+    "EQUITY_ADJUSTMENT_PCT": 0.05,
+    "EQUITY_ADJUSTMENT_ABS": 20.0
   },
   "trailing": {
     "arm_pips": 0.0,

--- a/src/main.py
+++ b/src/main.py
@@ -328,6 +328,20 @@ profit_guard = _profit_guard_for_mode(mode_env, broker)
 
 def _startup_checks() -> None:
     broker.connectivity_check()
+    try:
+        equity = broker.account_equity()
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[STARTUP-RESET][WARN] Unable to fetch equity for reset: {exc}", flush=True)
+        return
+
+    try:
+        open_trades = _open_trades_state()
+        open_count = len(open_trades or [])
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"[STARTUP-RESET][WARN] Unable to inspect open trades: {exc}", flush=True)
+        open_count = 0
+
+    risk.startup_daily_reset(equity, open_positions_count=open_count)
 
 
 def _open_trades_state() -> List[Dict]:


### PR DESCRIPTION
## Summary
- add startup daily baseline reset (demo always, live when no open trades) to clear latched caps and realign daily metrics
- extend risk state to track peak_equity_today, daily_pl, drawdown_pct, and daily loss cap flag for persistence
- log startup resets and warn when equity adjustments shift baselines; add tests covering resets and live/demo behavior

## Testing
- PYTHONPATH=. pytest tests/test_risk_manager.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69564aacff048329b4919319faa3291c)