### PR TITLE
Fix heartbeat scope and restore scheduler

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -686,8 +686,9 @@ def _log_projector(evaluation: Evaluation, now_utc: datetime) -> None:
         f"vol={volatility} range={range_fmt}",
         flush=True,
     )
-    
-    
+
+
+async def heartbeat() -> None:
     watchdog.last_heartbeat_ts = datetime.now(timezone.utc)
 
     ts_local = datetime.now(timezone.utc).astimezone().isoformat()
@@ -703,10 +704,7 @@ def _log_projector(evaluation: Evaluation, now_utc: datetime) -> None:
     except Exception:
         trade_count = "unknown"
 
-    print(
-        f"[JOURNAL] total_trades={trade_count}",
-        flush=True,
-    )
+    print(f"[JOURNAL] total_trades={trade_count}", flush=True)
 
     BOT_STATE.update({
         "status": "running",


### PR DESCRIPTION
### Motivation
- The heartbeat code was embedded inside `_log_projector`, which prevented a proper top-level coroutine from being scheduled reliably.
- A dedicated top-level coroutine is needed so the APScheduler can invoke periodic status updates independently of projector activity.
- Restoring the heartbeat to a top-level coroutine ensures journal counts and heartbeat logs are produced on schedule.

### Description
- Removed the nested heartbeat block from `_log_projector` and added a top-level `async def heartbeat()` coroutine with the same behavior.
- The new `heartbeat` updates `watchdog.last_heartbeat_ts`, reads `broker.account_equity()`, computes open trades with `_open_trades_state()`, counts journal lines using `default_journal_path(DATA_DIR)`, and updates `BOT_STATE`.
- Kept the existing console output format with `[JOURNAL]` and `[HEARTBEAT]` prints for observability.
- The scheduler is configured to run the coroutine via `scheduler.add_job(heartbeat, "interval", minutes=1)` and the runner still awaits `heartbeat()` at startup.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69636e8e378083299428a41f066c7e68)