### PR TITLE
Fix syntax and indentation errors in src/main.py

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -715,17 +715,6 @@ def _log_projector(evaluation: Evaluation, now_utc: datetime) -> None:
         f"vol={volatility} range={range_fmt}",
         flush=True,
     )
-    
-
-
-
-
-
-    )
-  
-
-
-
 
 async def decision_cycle() -> None:
     now_utc = datetime.now(timezone.utc)
@@ -1006,13 +995,15 @@ async def runner() -> None:
     await heartbeat()
     await decision_cycle()
     while True:
-       await asyncio.sleep(3600)
+        await asyncio.sleep(3600)
+
+
 def start_status_server():
     app = Flask(__name__)
 
     @app.route("/status", methods=["GET"])
     def status():
-    return jsonify(BOT_STATE)
+        return jsonify(BOT_STATE)
 
     port = int(os.environ.get("PORT", 10000))
     app.run(host="0.0.0.0", port=port)


### PR DESCRIPTION
### Motivation
- Tests and import-time execution were failing due to a stray closing parenthesis and mis-indentation in the main runtime file, preventing test collection and service startup. 
- The changes aim to restore correct syntax and block structure so the app can be executed and deployed (e.g. to Render) and so automated tests run cleanly. 

### Description
- Removed a stray closing parenthesis left after the `_log_projector` print block in `src/main.py`. 
- Fixed indentation in the async `runner()` loop so the `await asyncio.sleep(3600)` line is correctly indented. 
- Fixed indentation of the Flask status endpoint so the `return jsonify(BOT_STATE)` is inside the `status()` handler. 
- Updated only `src/main.py` to correct these issues and cleaned up the surrounding whitespace.

### Testing
- Ran `pytest -q` which initially failed during collection with a `SyntaxError` and `IndentationError` before the fixes. 
- After the fixes, ran `pytest -q` again and all tests passed: `95 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696474d562388329be0693e0200e06ec)