### PR TITLE
Add loss-streak pause guardrails to RiskManager

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -43,6 +43,8 @@
     "cooldown_minutes": 45,
     "daily_loss_cap_pct": 0.01,
     "weekly_loss_cap_pct": 0.03,
+    "loss_streak_limit": 3,
+    "loss_streak_pause_minutes": 45,
     "sl_atr_mult": 1.2,
     "tp_atr_mult": 1.0,
     "atr_period": 14,


### PR DESCRIPTION
### Motivation
- Reduce risk of cascade losses by pausing new entries after a configurable number of consecutive losing exits. 
- Ensure the pause is persisted across restarts and automatically cleared on daily rollover so recovery is safe and observable.

### Description
- Add `loss_streak_pause_until` to `RiskState` and persist it in `to_dict` / `from_dict`, and clear it on daily rollover in `src/risk_manager.py`.
- Introduce configuration defaults `loss_streak_limit` and `loss_streak_pause_minutes` in `config/defaults.json` and expose them as `self.loss_streak_limit` and `self.loss_streak_pause_minutes` in `RiskManager`.
- Implement `_apply_loss_streak_pause()` which checks the last N exits for consecutive losses and sets `loss_streak_pause_until` when the threshold is hit, and call it from `register_exit`.
- Block new entries in `should_open` while `now_utc < loss_streak_pause_until` and log the pause; reset the pause at the start of a new day.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970dd80a05483298756e6d9b666d193)