### PR TITLE
Docs: Clarify PR → Render auto-deploy release flow

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,5 +1,27 @@
 # Deployment Notes
 
+## Standard release flow (recommended)
+
+Use this sequence for normal changes:
+
+1. Create a branch and commit your changes.
+2. Open a pull request into `main`.
+3. Merge the pull request.
+4. Let Render auto-deploy from `main`.
+
+Why this is the default here:
+
+- `render.yaml` enables `autoDeploy: true` for services, so new commits on the tracked branch deploy automatically.
+- Service setup in `finish_render_setup.py` points Render services to repository branch `main`.
+
+## When manual deploy steps are needed
+
+You may need manual intervention only when:
+
+- auto-deploy is disabled in the Render dashboard,
+- a deployment is stuck/failed and needs retry,
+- you are performing rollback/hotfix operations.
+
 ## Instrument Configuration
 
 - Omit the `instruments` key or set it to `null`/`None` to use the default instrument basket.


### PR DESCRIPTION
### Motivation
- Remove ambiguity about whether manual Render deploy steps are required after PRs by documenting the normal release sequence and the limited cases that need manual intervention.

### Description
- Add a ``Standard release flow (recommended)`` section describing the sequence (create branch, open PR into ``main``, merge, let Render auto-deploy) and note that ``render.yaml`` enables ``autoDeploy: true`` and services are configured to track ``main``, and add a ``When manual deploy steps are needed`` section covering disabled auto-deploy, stuck/failed deploys, and rollback/hotfix scenarios.

### Testing
- Ran repository consistency checks and basic repository validation steps (including ``git diff --check``); all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ae3b3a56c8329b40fab23fe80c348)