### PR TITLE
Enable bounded aggressive test profile in Render defaults and document it

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -22,6 +22,21 @@ You may need manual intervention only when:
 - a deployment is stuck/failed and needs retry,
 - you are performing rollback/hotfix operations.
 
+## Aggressive test profile (higher activity, bounded risk)
+
+For short test windows where you want more entries than `SOFT` mode but still avoid reckless sizing:
+
+- `SESSION_MODE=ALWAYS`
+- `AGGRESSIVE_MODE=true`
+- `AGGRESSIVE_RISK_PCT=0.004` (0.4% risk per trade)
+- `AGGRESSIVE_MAX_POSITIONS=3`
+- `AGGRESSIVE_COOLDOWN_CANDLES=2`
+- `AGGRESSIVE_DAILY_LOSS_CAP_PCT=0.02`
+- `AGGRESSIVE_WEEKLY_LOSS_CAP_PCT=0.05`
+- `AGGRESSIVE_MAX_DRAWDOWN_CAP_PCT=0.15`
+
+This is intentionally higher-tempo than default, but still constrained by loss caps/drawdown limits.
+
 ## Instrument Configuration
 
 - Omit the `instruments` key or set it to `null`/`None` to use the default instrument basket.

--- a/render.yaml
+++ b/render.yaml
@@ -17,6 +17,22 @@ services:
         value: "30"
       - key: DECISION_SECONDS
         value: "60"
+      - key: SESSION_MODE
+        value: "ALWAYS"
+      - key: AGGRESSIVE_MODE
+        value: "true"
+      - key: AGGRESSIVE_RISK_PCT
+        value: "0.004"
+      - key: AGGRESSIVE_MAX_POSITIONS
+        value: "3"
+      - key: AGGRESSIVE_COOLDOWN_CANDLES
+        value: "2"
+      - key: AGGRESSIVE_DAILY_LOSS_CAP_PCT
+        value: "0.02"
+      - key: AGGRESSIVE_WEEKLY_LOSS_CAP_PCT
+        value: "0.05"
+      - key: AGGRESSIVE_MAX_DRAWDOWN_CAP_PCT
+        value: "0.15"
       - key: OANDA_API_KEY
         sync: false
       - key: INSTRUMENTS

--- a/src/main.py
+++ b/src/main.py
@@ -552,8 +552,12 @@ def _macd_confirms(signal: str, diagnostics: Dict[str, float] | None) -> tuple[b
     macd_histogram = _coerce(diagnostics.get("macd_histogram"))
     macd_histogram_prev = _coerce(diagnostics.get("macd_histogram_prev"))
 
+    # Fail-open when MACD inputs are unavailable.
+    # In live feeds, startup windows or partial diagnostics can temporarily
+    # produce NaN values; blocking all entries in that state makes the bot
+    # appear "stuck" and not trading.
     if any(math.isnan(val) for val in (macd_line, macd_signal, macd_histogram)):
-        return False, macd_line, macd_signal, macd_histogram
+        return True, macd_line, macd_signal, macd_histogram
 
     hist_rising = False
     hist_falling = False

--- a/tests/test_macd_confirmation.py
+++ b/tests/test_macd_confirmation.py
@@ -228,6 +228,103 @@ def test_macd_confirmation_allows_trade(monkeypatch):
     _reset_clock(original_datetime)
 
 
+def test_macd_missing_values_do_not_block_trade(monkeypatch):
+    class DummyRisk:
+        risk_per_trade_pct = 0.001
+
+        def should_open(self, *args, **kwargs):
+            return True, "ok"
+
+        def sl_distance_from_atr(self, atr, instrument=None):
+            return 0.5
+
+        def tp_distance_from_atr(self, atr, instrument=None):
+            return 1.0
+
+        def register_entry(self, now_utc, instrument: str):
+            pass
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self.marked: List[str] = []
+
+        def evaluate_all(self) -> List[Evaluation]:
+            return [
+                Evaluation(
+                    instrument="EUR_USD",
+                    signal="BUY",
+                    diagnostics={
+                        "atr": 0.01,
+                        "atr_baseline_50": 0.01,
+                        "rsi": 60.0,
+                        "close": 1.2345,
+                        "ema_trend_fast": 1.25,
+                        "ema_trend_slow": 1.2,
+                        # MACD fields intentionally omitted to simulate
+                        # temporary indicator warm-up/unavailable feed values.
+                    },
+                    reason="bullish",
+                    market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
+                )
+            ]
+
+        def mark_trade(self, instrument: str) -> None:
+            self.marked.append(instrument)
+
+    class DummyBroker:
+        def __init__(self) -> None:
+            self.calls: List[Dict[str, object]] = []
+
+        def place_order(
+            self,
+            instrument: str,
+            signal: str,
+            units: int,
+            *args,
+            **kwargs,
+        ) -> Dict[str, str]:
+            self.calls.append({"instrument": instrument, "signal": signal, "units": units})
+            return {"status": "SENT"}
+
+        def account_equity(self) -> float:
+            return 10_000.0
+
+        def current_spread(self, instrument: str) -> float:
+            return 0.5
+
+        def close_all_positions(self) -> None:
+            pass
+
+    dummy_engine = DummyEngine()
+    dummy_broker = DummyBroker()
+    dummy_risk = DummyRisk()
+    monkeypatch.setitem(main.config, "use_macd_confirmation", True)
+    monkeypatch.setattr(main, "engine", dummy_engine)
+    monkeypatch.setattr(main, "broker", dummy_broker)
+    monkeypatch.setattr(main, "risk", dummy_risk)
+    monkeypatch.setattr(main, "profit_guard", type("PG", (), {"process_open_trades": lambda self, trades: []})())
+    monkeypatch.setattr(main, "_open_trades_state", lambda: [])
+    monkeypatch.setattr(main.session_filter, "session_decision", lambda *args, **kwargs: _allow_session_decision())
+    monkeypatch.setattr(
+        main.position_sizer,
+        "units_for_risk",
+        lambda equity, entry_price, stop_distance, risk_pct: 100,
+    )
+    original_datetime, original_ts, before, watchdog = _set_heartbeat(monkeypatch)
+
+    asyncio.run(main.decision_cycle())
+
+    assert dummy_engine.marked == ["EUR_USD"]
+    assert dummy_broker.calls == [{"instrument": "EUR_USD", "signal": "BUY", "units": 100}]
+    watchdog.last_decision_ts = original_ts
+    _reset_clock(original_datetime)
+
+
 def test_trailing_flow_unchanged_with_macd(monkeypatch):
     class DummyRisk:
         risk_per_trade_pct = 0.001


### PR DESCRIPTION
### Motivation
- Provide a higher-activity, always-on test profile so the worker can be exercised without `SOFT` off-session gating while keeping sizing and loss limits bounded.
- Surface the profile in deployment docs so testers know the intended risk bounds and can reproduce the setup quickly.
- Preserve prior reliability fixes that avoid stalls when MACD diagnostics are temporarily unavailable.

### Description
- Update `render.yaml` to add environment defaults for `SESSION_MODE=ALWAYS` and an aggressive-but-bounded profile via `AGGRESSIVE_MODE=true`, `AGGRESSIVE_RISK_PCT=0.004`, `AGGRESSIVE_MAX_POSITIONS=3`, `AGGRESSIVE_COOLDOWN_CANDLES=2`, `AGGRESSIVE_DAILY_LOSS_CAP_PCT=0.02`, `AGGRESSIVE_WEEKLY_LOSS_CAP_PCT=0.05`, and `AGGRESSIVE_MAX_DRAWDOWN_CAP_PCT=0.15` so the worker runs with higher tempo in test deployments.
- Add an `Aggressive test profile (higher activity, bounded risk)` section to `docs/DEPLOYMENT.md` documenting the env vars and recommended constraints for short test windows.
- Retain prior change to `_macd_confirms` in `src/main.py` to "fail-open" when MACD inputs are missing so temporary indicator warm-up does not block entries, and include the new regression test `test_macd_missing_values_do_not_block_trade` in `tests/test_macd_confirmation.py` to validate that behavior.

### Testing
- Ran the full test suite with `pytest -q`; result: `96 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699be9cbb89c8329b3cac75ceac18aec)