### PR TITLE
Add durable SQLite trade-events journal, waitress status server, and opt-in "beast mode" with tests

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -18,7 +18,7 @@
   "rsi_slope_min": 0.1,
   "adx_filter": 20,
   "atr_length": 14,
-  "min_atr": 0.00005,
+  "min_atr": 5e-05,
   "xau_atr_guard_ratio": 1.8,
   "xau_atr_guard_action": "skip",
   "xau_atr_guard_size_scale": 0.5,
@@ -88,5 +88,11 @@
     "minutes": 90,
     "min_pips": 2.0,
     "xau_atr_mult": 0.35
-  }
+  },
+  "aggressive_test_mode": false,
+  "aggressive_test_mode_note": "Demo/testing only: enables SESSION_MODE=ALWAYS while keeping spread/news filters active; review before any live use.",
+  "aggressive_risk_pct": 0.004,
+  "agg_max_total_open_risk": 0.02,
+  "daily_max_drawdown": 0.03,
+  "weekly_max_drawdown": 0.05
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest==8.3.3
 pydantic-settings==2.5.2
 requests
 flask
+waitress

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,7 @@ import math
 import uuid
 from flask import Flask, jsonify
 import threading
+from waitress import serve
 
 
 def send_snapshot(user: str, equity: float) -> None:
@@ -240,6 +241,11 @@ config["use_macd_confirmation"] = _as_bool(
     os.getenv("USE_MACD_CONFIRMATION", config.get("use_macd_confirmation", False))
 )
 config["session_mode"] = (os.getenv("SESSION_MODE") or config.get("session_mode") or "SOFT").upper()  # MINI-RUN: default to SOFT for boundary-friendly entries
+aggressive_test_mode = _as_bool(os.getenv("AGGRESSIVE_TEST_MODE", config.get("aggressive_test_mode", False)))
+# Demo/testing-only beast mode: this can increase turnover and risk and should be reviewed before live usage.
+config["aggressive_test_mode"] = aggressive_test_mode
+if aggressive_test_mode:
+    config["session_mode"] = "ALWAYS"
 config["session_off_session_vol_ratio"] = float(
     os.getenv("SESSION_OFF_SESSION_VOL_RATIO", config.get("session_off_session_vol_ratio", 1.25))
 )
@@ -295,6 +301,7 @@ risk_config["max_concurrent_positions"] = int(env_max_positions or max_positions
 risk_config.setdefault("daily_loss_cap_pct", float(os.getenv("DAILY_LOSS_CAP_PCT", risk_config.get("daily_loss_cap_pct", 0.02))))
 risk_config.setdefault("weekly_loss_cap_pct", float(os.getenv("WEEKLY_LOSS_CAP_PCT", risk_config.get("weekly_loss_cap_pct", 0.03))))
 risk_config.setdefault("max_drawdown_cap_pct", float(os.getenv("MAX_DRAWDOWN_CAP_PCT", risk_config.get("max_drawdown_cap_pct", 0.10))))
+risk_config.setdefault("max_total_open_risk_pct", float(os.getenv("MAX_TOTAL_OPEN_RISK", risk_config.get("max_total_open_risk_pct", 0.02))))
 risk_config.setdefault("daily_profit_target_usd", float(os.getenv("DAILY_PROFIT_TARGET_USD", risk_config.get("daily_profit_target_usd", 5.0))))
 risk_config["max_trades_per_day"] = int(os.getenv("MAX_TRADES_PER_DAY", risk_config.get("max_trades_per_day", 0) or 0))
 
@@ -310,6 +317,15 @@ if aggressive_mode:
     # Remove profit cap in aggressive/demo and widen take-profit allowance
     risk_config["daily_profit_target_usd"] = float(os.getenv("AGGRESSIVE_DAILY_PROFIT_CAP", 0.0))
     risk_cooldown_candles = risk_config["cooldown_candles"]
+
+if aggressive_test_mode:
+    # Beast mode is intentionally opt-in for demo testing only.
+    risk_config["risk_per_trade_pct"] = float(os.getenv("AGGRESSIVE_RISK_PCT", config.get("aggressive_risk_pct", 0.004)))
+    risk_config["max_total_open_risk_pct"] = float(
+        os.getenv("AGG_MAX_TOTAL_OPEN_RISK", config.get("agg_max_total_open_risk", 0.02))
+    )
+    risk_config["daily_loss_cap_pct"] = float(os.getenv("DAILY_MAX_DRAWDOWN", config.get("daily_max_drawdown", 0.03)))
+    risk_config["weekly_loss_cap_pct"] = float(os.getenv("WEEKLY_MAX_DRAWDOWN", config.get("weekly_max_drawdown", 0.05)))
 
 config["cooldown_candles"] = risk_cooldown_candles
 config["cooldown_minutes"] = risk_tf_minutes * risk_cooldown_candles if risk_tf_minutes else config.get("cooldown_minutes", 0)
@@ -342,16 +358,19 @@ async def heartbeat() -> None:
     equity = broker.account_equity()
     open_count = len(_open_trades_state())
 
-    trade_count = "unknown"
+    journal_path = journal.path
+    journal_exists = journal_path.exists()
     try:
-        journal_path = default_journal_path(DATA_DIR)
-        if journal_path.exists():
-            with journal_path.open("r", encoding="utf-8") as f:
-                trade_count = sum(1 for _ in f)
-    except Exception:
-        trade_count = "unknown"
-
-    print(f"[JOURNAL] total_trades={trade_count}", flush=True)
+        trade_count = journal.count_trade_events()
+        print(
+            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} total_trades={trade_count}",
+            flush=True,
+        )
+    except Exception as exc:
+        print(
+            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} error={exc}",
+            flush=True,
+        )
 
     BOT_STATE.update({
         "status": "running",
@@ -961,6 +980,7 @@ async def decision_cycle() -> None:
                         run_tag=MINI_RUN_TAG,
                         gating_flags=gating_flags,
                         indicators_snapshot=indicators_snapshot,
+                        equity_after=equity,
                     )
                 except Exception:
                     # Journal failures must not block live execution.
@@ -1010,10 +1030,14 @@ def start_status_server():
         return jsonify(BOT_STATE)
 
     port = int(os.environ.get("PORT", 10000))
-    app.run(host="0.0.0.0", port=port)
+    serve(app, host="0.0.0.0", port=port)
 
 
-threading.Thread(target=start_status_server, daemon=True).start()
+def launch_status_server_thread() -> threading.Thread:
+    thread = threading.Thread(target=start_status_server, daemon=True)
+    thread.start()
+    return thread
 
 if __name__ == "__main__":
+    launch_status_server_thread()
     asyncio.run(runner())

--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -1119,6 +1119,11 @@ class ProfitProtection:
                 final_profit=final_profit,
                 now_utc=now_val,
             )
+            equity_after = None
+            try:
+                equity_after = float(self.broker.account_equity())
+            except Exception:
+                equity_after = None
             try:
                 self._journal.record_exit(
                     trade_id=str(trade_id or instrument or ""),
@@ -1131,6 +1136,10 @@ class ProfitProtection:
                     duration_seconds=int(summary["duration_sec"] or 0),  # type: ignore[arg-type]
                     broker_confirmed=closed_by == "broker_confirmed",
                     run_tag=None,
+                    instrument=instrument,
+                    direction=state.side if state else None,
+                    entry_price=state.entry_price if state else None,
+                    equity_after=equity_after,
                 )
             except Exception:
                 # Journal failures must never block trade lifecycle.

--- a/src/trade_journal.py
+++ b/src/trade_journal.py
@@ -61,6 +61,7 @@ class TradeJournal:
             isolation_level=None,  # autocommit
             check_same_thread=False,
         )
+        conn.execute("PRAGMA busy_timeout=5000;")
         conn.execute("PRAGMA journal_mode=WAL;")
         conn.execute("PRAGMA synchronous=NORMAL;")
         return conn
@@ -98,6 +99,21 @@ class TradeJournal:
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_trades_instrument_ts ON trades (instrument, timestamp_utc);"
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS trade_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp TEXT,
+                    instrument TEXT,
+                    direction TEXT,
+                    entry_price REAL,
+                    exit_price REAL,
+                    profit REAL,
+                    reason TEXT,
+                    equity_after REAL
+                );
+                """
+            )
             # Migration-safe: add run_tag if missing.
             columns = {row[1] for row in conn.execute("PRAGMA table_info(trades);").fetchall()}
             if "run_tag" not in columns:
@@ -120,6 +136,7 @@ class TradeJournal:
         run_tag: Optional[str] = None,
         gating_flags: Mapping[str, Any],
         indicators_snapshot: Mapping[str, Any],
+        equity_after: Optional[float] = None,
     ) -> None:
         if not trade_id:
             return
@@ -191,6 +208,30 @@ class TradeJournal:
                 """,
                 payload,
             )
+            conn.execute(
+                """
+                INSERT INTO trade_events (
+                    timestamp,
+                    instrument,
+                    direction,
+                    entry_price,
+                    exit_price,
+                    profit,
+                    reason,
+                    equity_after
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    payload["timestamp_utc"],
+                    instrument,
+                    side,
+                    entry_price,
+                    None,
+                    None,
+                    "OPEN",
+                    equity_after,
+                ),
+            )
 
     def record_exit(
         self,
@@ -205,6 +246,10 @@ class TradeJournal:
         duration_seconds: Optional[int],
         broker_confirmed: Optional[bool],
         run_tag: Optional[str] = None,
+        instrument: Optional[str] = None,
+        direction: Optional[str] = None,
+        entry_price: Optional[float] = None,
+        equity_after: Optional[float] = None,
     ) -> None:
         if not trade_id:
             return
@@ -264,6 +309,42 @@ class TradeJournal:
                 """,
                 payload,
             )
+            existing_trade = conn.execute(
+                "SELECT instrument, side, entry_price FROM trades WHERE trade_id=?",
+                (str(trade_id),),
+            ).fetchone()
+            resolved_instrument = instrument if instrument is not None else (existing_trade[0] if existing_trade else None)
+            resolved_direction = direction if direction is not None else (existing_trade[1] if existing_trade else None)
+            resolved_entry = entry_price if entry_price is not None else (existing_trade[2] if existing_trade else None)
+            conn.execute(
+                """
+                INSERT INTO trade_events (
+                    timestamp,
+                    instrument,
+                    direction,
+                    entry_price,
+                    exit_price,
+                    profit,
+                    reason,
+                    equity_after
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    payload["exit_timestamp_utc"],
+                    resolved_instrument,
+                    resolved_direction,
+                    resolved_entry,
+                    exit_price,
+                    realized_pnl_ccy,
+                    exit_reason,
+                    equity_after,
+                ),
+            )
+
+    def count_trade_events(self) -> int:
+        with self._connect() as conn:
+            row = conn.execute("SELECT COUNT(*) FROM trade_events").fetchone()
+            return int(row[0] if row else 0)
 
 
 __all__ = ["TradeJournal", "default_journal_path"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import sys
+import types
+
+# Test environments may not have external dependencies pre-installed.
+# Provide a minimal waitress shim so imports of `from waitress import serve`
+# work during unit tests; production uses the real package from requirements.
+if "waitress" not in sys.modules:
+    waitress_stub = types.ModuleType("waitress")
+
+    def _serve(*args, **kwargs):
+        return None
+
+    waitress_stub.serve = _serve
+    sys.modules["waitress"] = waitress_stub

--- a/tests/test_beast_mode.py
+++ b/tests/test_beast_mode.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from datetime import datetime, timezone
+
+import src.session_filter as session_filter
+
+
+def _reload_main(monkeypatch, **env):
+    for key in [
+        "AGGRESSIVE_TEST_MODE",
+        "SESSION_MODE",
+        "AGGRESSIVE_RISK_PCT",
+        "AGG_MAX_TOTAL_OPEN_RISK",
+        "DAILY_MAX_DRAWDOWN",
+        "WEEKLY_MAX_DRAWDOWN",
+    ]:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    fake_waitress = types.ModuleType("waitress")
+    fake_waitress.serve = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "waitress", fake_waitress)
+
+    sys.modules.pop("src.main", None)
+    import src.main as main_mod
+
+    return importlib.reload(main_mod)
+
+
+def test_beast_mode_forces_always_session(monkeypatch):
+    main_mod = _reload_main(
+        monkeypatch,
+        AGGRESSIVE_TEST_MODE="true",
+        AGGRESSIVE_RISK_PCT="0.004",
+        AGG_MAX_TOTAL_OPEN_RISK="0.02",
+        DAILY_MAX_DRAWDOWN="0.03",
+        WEEKLY_MAX_DRAWDOWN="0.05",
+    )
+
+    assert main_mod.config["aggressive_test_mode"] is True
+    assert main_mod.config["session_mode"] == "ALWAYS"
+    assert main_mod.config["risk"]["risk_per_trade_pct"] == 0.004
+
+    decision = session_filter.session_decision(
+        datetime(2024, 1, 1, 22, 0, tzinfo=timezone.utc),
+        mode=main_mod.config["session_mode"],
+        atr=1.0,
+        atr_baseline=1.0,
+        trend_aligned=False,
+    )
+    assert decision.allowed is True
+
+
+def test_normal_session_gating_unchanged_without_beast_mode(monkeypatch):
+    main_mod = _reload_main(monkeypatch, SESSION_MODE="STRICT", AGGRESSIVE_TEST_MODE="false")
+
+    assert main_mod.config["aggressive_test_mode"] is False
+    assert main_mod.config["session_mode"] == "STRICT"
+
+    decision = session_filter.session_decision(
+        datetime(2024, 1, 1, 22, 0, tzinfo=timezone.utc),
+        mode=main_mod.config["session_mode"],
+    )
+    assert decision.allowed is False
+
+
+def test_status_server_uses_waitress(monkeypatch):
+    main_mod = _reload_main(monkeypatch)
+
+    called = {}
+
+    def fake_serve(app, host, port):
+        called["app"] = app
+        called["host"] = host
+        called["port"] = port
+
+    monkeypatch.setenv("PORT", "12345")
+    monkeypatch.setattr(main_mod, "serve", fake_serve)
+
+    main_mod.start_status_server()
+
+    assert called["host"] == "0.0.0.0"
+    assert called["port"] == 12345
+    assert hasattr(called["app"], "route")

--- a/tests/test_trade_journal.py
+++ b/tests/test_trade_journal.py
@@ -33,6 +33,7 @@ def test_trade_journal_entry_and_exit(tmp_path):
         run_tag="MINI_RUN",
         gating_flags={"session_ok": True, "risk_ok": True, "spread_ok": True},
         indicators_snapshot={"rsi": 55.5, "atr": 0.0007},
+        equity_after=1500.0,
     )
 
     with sqlite3.connect(db_path) as conn:
@@ -58,6 +59,7 @@ def test_trade_journal_entry_and_exit(tmp_path):
         duration_seconds=900,
         broker_confirmed=True,
         run_tag="MINI_RUN",
+        equity_after=1501.1,
     )
 
     with sqlite3.connect(db_path) as conn:
@@ -68,3 +70,8 @@ def test_trade_journal_entry_and_exit(tmp_path):
         assert row[8] == "TRAIL"
         assert row[9] == 900
         assert row[10] == 1
+
+        event_count = conn.execute("SELECT COUNT(*) FROM trade_events").fetchone()[0]
+        assert event_count == 2
+
+    assert journal.count_trade_events() == 2


### PR DESCRIPTION
### Motivation

- Provide a reliable, concurrent-safe persistent trade journal that records real trade open/close events to support auditing and demos. 
- Remove Flask dev-server logging noise by using a production WSGI server for the status endpoint without affecting the main trading loop. 
- Add an opt-in aggressive demo configuration for high-throughput testing while keeping normal behaviour unchanged by default.

### Description

- Hardened SQLite journaling in `src/trade_journal.py` to use `PRAGMA journal_mode=WAL` and `PRAGMA busy_timeout=5000`, added a `trade_events` table and `count_trade_events()` helper, and write an event row on entry and exit with columns: `timestamp`, `instrument`, `direction`, `entry_price`, `exit_price`, `profit`, `reason`, `equity_after`.
- Heartbeat now reports the actual journal path and existence and prints `total_trades` by calling `journal.count_trade_events()` and reports DB open/count errors instead of an ambiguous `unknown` (changes in `src/main.py`).
- Status server now uses `waitress.serve(app, host, port)` instead of `app.run(...)`, and the server is launched in a daemon thread via `launch_status_server_thread()` so the main `asyncio` trading loop is unaffected (`src/main.py`).
- Added demo-only "beast mode": new config/environment handling for `AGGRESSIVE_TEST_MODE` that forces `SESSION_MODE=ALWAYS` when enabled and applies the requested aggressive risk knobs (`AGGRESSIVE_RISK_PCT`, `AGG_MAX_TOTAL_OPEN_RISK`, `DAILY_MAX_DRAWDOWN`, `WEEKLY_MAX_DRAWDOWN`) while leaving all existing trade logic, position sizing, stops and signal calculations intact; config keys and defaults added to `config/defaults.json` and wiring in `src/main.py`.
- When trades are opened/closed, the code now records `equity_after` snapshots where available (wiring in `src/main.py` and `src/profit_protection.py`) so `trade_events` reflect lifecycle with equity reporting.
- Added `waitress` to `requirements.txt` for production deployments and included a test shim `tests/conftest.py` so unit tests run in environments where external packages are not preinstalled.
- Added regression tests: `tests/test_trade_journal.py` (verifies event rows and `count_trade_events()`), `tests/test_beast_mode.py` (beast-mode behaviour, normal session gating, and status server using `waitress`), and a small `tests/conftest.py` shim.

### Testing

- Ran unit test subsets and full suites with `PYTHONPATH=. pytest` including `tests/test_trade_journal.py`, `tests/test_beast_mode.py`, `tests/test_session_filter.py`, `tests/test_main_instruments.py`, `tests/test_main_trailing_config.py`, and `tests/test_projector.py`, and all tests passed locally in the CI-like environment (`19 passed` + `4 passed` runs observed during validation; final run showed `19 passed` and project-specific tests also passed).
- Verified `heartbeat()` output now prints `JOURNAL` lines containing `path=<path> exists=<true/false> total_trades=<n>` and surfaces DB errors when the DB cannot be opened (exercise performed via tests and local runs).
- Note: `pip install waitress` was attempted but blocked by network/proxy in this runtime; tests succeeded using the included test shim (`tests/conftest.py`), and `waitress` remains listed in `requirements.txt` for production deployment environments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bfffbcdb4832983af209247ae137b)