### PR TITLE
Adaptive sizing, risk-cap enforcement, performance reporting and enhanced logging

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ pydantic-settings==2.5.2
 requests
 flask
 waitress
+
+reportlab

--- a/src/adaptive_tuner.py
+++ b/src/adaptive_tuner.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import inspect
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class AdaptiveSnapshot:
+    closed_trades: int
+    wins: int
+    losses: int
+    loss_streak: int
+    risk_multiplier: float
+    source: str = "none"
+
+
+class AdaptiveTuner:
+    """Read-only adaptive sizing helper based on recent closed-trade outcomes."""
+
+    def __init__(self, db_path: Path, *, lookback: int = 40, min_sample: int = 10) -> None:
+        self.db_path = Path(db_path)
+        self.lookback = max(10, int(lookback))
+        self.min_sample = max(3, int(min_sample))
+
+    def _load_recent_pnl_from_trades(self, conn: sqlite3.Connection) -> list[float]:
+        rows = conn.execute(
+            """
+            SELECT COALESCE(realized_pnl_ccy, 0.0) AS pnl
+            FROM trades
+            WHERE exit_timestamp_utc IS NOT NULL
+            ORDER BY exit_timestamp_utc DESC
+            LIMIT ?
+            """,
+            (self.lookback,),
+        ).fetchall()
+        return [float(row[0] or 0.0) for row in rows]
+
+    def _load_recent_pnl_from_events(self, conn: sqlite3.Connection) -> list[float]:
+        rows = conn.execute(
+            """
+            SELECT COALESCE(profit, 0.0) AS pnl
+            FROM trade_events
+            WHERE reason != 'OPEN' AND profit IS NOT NULL
+            ORDER BY id DESC
+            LIMIT ?
+            """,
+            (self.lookback,),
+        ).fetchall()
+        return [float(row[0] or 0.0) for row in rows]
+
+    def _load_recent_pnl(self) -> tuple[list[float], str]:
+        if not self.db_path.exists():
+            return [], "none"
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            pnl_trades = self._load_recent_pnl_from_trades(conn)
+            if len(pnl_trades) >= self.min_sample:
+                return pnl_trades, "trades"
+
+            pnl_events = self._load_recent_pnl_from_events(conn)
+            if pnl_events:
+                return pnl_events, "trade_events"
+
+            return pnl_trades, "trades"
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _loss_streak(recent_desc: list[float]) -> int:
+        streak = 0
+        for pnl in recent_desc:
+            if pnl < 0:
+                streak += 1
+            else:
+                break
+        return streak
+
+
+    @staticmethod
+    def _build_snapshot(*, closed_trades: int, wins: int, losses: int, loss_streak: int, risk_multiplier: float, source: str) -> AdaptiveSnapshot:
+        """Build snapshot compatibly across mixed deployments.
+
+        Some environments may still have an older AdaptiveSnapshot signature
+        without the ``source`` field when stale bytecode is loaded.
+        """
+        payload = {
+            "closed_trades": closed_trades,
+            "wins": wins,
+            "losses": losses,
+            "loss_streak": loss_streak,
+            "risk_multiplier": risk_multiplier,
+            "source": source,
+        }
+        try:
+            return AdaptiveSnapshot(**payload)
+        except TypeError:
+            params = inspect.signature(AdaptiveSnapshot).parameters
+            compatible_payload = {key: value for key, value in payload.items() if key in params}
+            return AdaptiveSnapshot(**compatible_payload)
+
+    def snapshot(self) -> AdaptiveSnapshot:
+        recent, source = self._load_recent_pnl()
+        closed = len(recent)
+        wins = sum(1 for pnl in recent if pnl > 0)
+        losses = sum(1 for pnl in recent if pnl < 0)
+        loss_streak = self._loss_streak(recent)
+
+        # Fast-start conservative mode until sufficient sample is available.
+        if closed < self.min_sample:
+            multiplier = 0.85
+        else:
+            win_rate = wins / closed if closed else 0.0
+            if loss_streak >= 3:
+                multiplier = 0.6
+            elif loss_streak >= 2:
+                multiplier = 0.75
+            elif win_rate < 0.4:
+                multiplier = 0.8
+            elif win_rate > 0.6:
+                multiplier = 1.0
+            else:
+                multiplier = 0.9
+
+        return self._build_snapshot(
+            closed_trades=closed,
+            wins=wins,
+            losses=losses,
+            loss_streak=loss_streak,
+            risk_multiplier=max(0.5, min(1.0, multiplier)),
+            source=source,
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import inspect
 import sys
 import math
+import subprocess
 import uuid
 from flask import Flask, jsonify
 import threading
+import time
 from waitress import serve
 
 
@@ -46,6 +49,15 @@ import src.profit_protection as profit_protection
 from src.profit_protection import ProfitProtection
 from src import orb, session_filter
 from src import position_sizer
+from src.adaptive_tuner import AdaptiveTuner
+
+try:
+    # Compatibility symbol for older diagnostic format:
+    # f"[ADAPTIVE] module={AdaptiveSnapshot.__module__} ..."
+    from src.adaptive_tuner import AdaptiveSnapshot as AdaptiveSnapshot
+except Exception:  # pragma: no cover - defensive fallback
+    class AdaptiveSnapshot:  # type: ignore[no-redef]
+        __module__ = "unavailable"
 
 
 
@@ -56,7 +68,7 @@ from src.risk_setup import (
     build_risk_manager,
     resolve_state_dir,
 )
-from src.trade_journal import TradeJournal, default_journal_path
+from src.trade_journal import TradeJournal, default_journal_path, run_performance_analysis
 
 VERSION = "v1.6.1"
 
@@ -64,7 +76,36 @@ CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "defaults.json
 DEFAULT_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 DATA_DIR = resolve_state_dir(DEFAULT_DATA_DIR)
 journal = TradeJournal(default_journal_path(DATA_DIR))
+adaptive_tuner = AdaptiveTuner(
+    journal.path,
+    lookback=int(os.getenv("ADAPTIVE_LOOKBACK", 40)),
+    min_sample=int(os.getenv("ADAPTIVE_MIN_SAMPLE", 8)),
+)
 MINI_RUN_TAG = "MINI_RUN"
+
+
+
+
+def _runtime_revision() -> str:
+    sha = os.getenv("RENDER_GIT_COMMIT") or os.getenv("GIT_COMMIT")
+    if sha:
+        return sha
+    try:
+        return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], text=True).strip()
+    except Exception:
+        return "unknown"
+
+def _adaptive_snapshot_signature() -> str:
+    try:
+        from src import adaptive_tuner as adaptive_module
+
+        snapshot_cls = getattr(adaptive_module, "AdaptiveSnapshot", None)
+        if snapshot_cls is None:
+            return "missing"
+        params = list(inspect.signature(snapshot_cls).parameters.keys())
+        return ",".join(params)
+    except Exception:
+        return "unavailable"
 
 
 def load_config(path: Path = CONFIG_PATH) -> Dict:
@@ -126,11 +167,18 @@ def _as_bool(value: object) -> bool:
     return bool(value)
 
 
+ADAPTIVE_TUNING_ENABLED = _as_bool(os.getenv("ADAPTIVE_TUNING_ENABLED", True))
+
+
 def _coerce_float(value: object, fallback: float = 0.0) -> float:
     try:
         return float(value)
     except (TypeError, ValueError):
         return fallback
+
+
+def _clamp_risk_pct(value: float, *, cap: float) -> float:
+    return max(0.001, min(float(value), float(cap)))
 
 
 def _build_trailing_config(config: Dict) -> Dict:
@@ -319,13 +367,26 @@ if aggressive_mode:
     risk_cooldown_candles = risk_config["cooldown_candles"]
 
 if aggressive_test_mode:
-    # Aggressive demo mode: disable daily profit cap gating and use larger per-trade risk.
-    risk_per_trade_pct = 2.5
+    # Aggressive demo mode: disable daily profit cap gating and use configurable per-trade risk.
+    risk_per_trade_pct = float(os.getenv("AGGRESSIVE_TEST_RISK_PCT", 2.5))
     risk_config["risk_per_trade_pct"] = risk_per_trade_pct / 100.0
     risk_config["daily_profit_target_usd"] = 0.0
     print("[CONFIG] Daily profit cap DISABLED (aggressive demo mode)", flush=True)
     print(f"[CONFIG] Risk per trade set to {risk_per_trade_pct}%", flush=True)
 
+risk_cap_pct = float(os.getenv("MAX_RISK_PER_TRADE_CAP_PCT", 1.0)) / 100.0
+risk_cap_enabled = _as_bool(os.getenv("ENABLE_RISK_CAP", aggressive_test_mode))
+if aggressive_test_mode and risk_cap_enabled and not _as_bool(os.getenv("ALLOW_HIGH_RISK", False)):
+    print(f"[CONFIG] risk cap enabled (aggressive test default) cap_pct={risk_cap_pct*100:.2f}%", flush=True)
+if risk_cap_enabled and not _as_bool(os.getenv("ALLOW_HIGH_RISK", False)):
+    original_risk_pct = float(risk_config.get("risk_per_trade_pct", 0.005))
+    capped_risk_pct = _clamp_risk_pct(original_risk_pct, cap=risk_cap_pct)
+    if capped_risk_pct != original_risk_pct:
+        print(
+            f"[CONFIG] risk_per_trade_pct capped from {original_risk_pct:.4f} to {capped_risk_pct:.4f}",
+            flush=True,
+        )
+    risk_config["risk_per_trade_pct"] = capped_risk_pct
 config["cooldown_candles"] = risk_cooldown_candles
 config["cooldown_minutes"] = risk_tf_minutes * risk_cooldown_candles if risk_tf_minutes else config.get("cooldown_minutes", 0)
 config["max_open_trades"] = int(os.getenv("MAX_OPEN_TRADES", risk_config.get("max_concurrent_positions", config.get("max_open_trades", 3))))
@@ -371,6 +432,15 @@ async def heartbeat() -> None:
             flush=True,
         )
 
+    print(
+        f"[RUNTIME] revision={_runtime_revision()} main={Path(__file__).resolve()}",
+        flush=True,
+    )
+    print(
+        f"[ADAPTIVE] module={adaptive_tuner.__class__.__module__} signature={_adaptive_snapshot_signature()}",
+        flush=True,
+    )
+
     BOT_STATE.update({
         "status": "running",
         "equity": float(equity),
@@ -383,6 +453,13 @@ async def heartbeat() -> None:
         flush=True,
     )
 
+    snap = _safe_adaptive_snapshot("heartbeat")
+    if snap is not None:
+        print(
+            f"[TRADING_SUMMARY] source={snap.source} closed={snap.closed_trades} wins={snap.wins} losses={snap.losses} loss_streak={snap.loss_streak} risk_mult={snap.risk_multiplier:.2f}",
+            flush=True,
+        )
+
 suppression_counters = {
     "signals_generated": 0,
     "signals_executed": 0,
@@ -392,6 +469,17 @@ suppression_counters = {
     "blocked_spread": 0,
 }
 
+
+
+
+def _safe_adaptive_snapshot(context: str):
+    if not ADAPTIVE_TUNING_ENABLED:
+        return None
+    try:
+        return adaptive_tuner.snapshot()
+    except Exception as exc:
+        print(f"[ADAPTIVE][WARN] context={context} snapshot_failed error={exc}", flush=True)
+        return None
 
 def _profit_guard_for_mode(mode: str, broker_instance: Broker) -> ProfitProtection:
     return build_profit_protection(
@@ -423,6 +511,24 @@ def _startup_checks() -> None:
         open_count = 0
 
     risk.startup_daily_reset(equity, open_positions_count=open_count)
+
+    if _as_bool(os.getenv("RESET_MAX_DRAWDOWN_HALT", False)):
+        if risk.clear_max_drawdown_halt(equity):
+            print(
+                f"[RISK] RESET_MAX_DRAWDOWN_HALT applied at equity={float(equity):.2f}",
+                flush=True,
+            )
+        else:
+            print("[RISK] RESET_MAX_DRAWDOWN_HALT requested but no active halt found", flush=True)
+
+    if _as_bool(os.getenv("RESET_WEEKLY_LOSS_CAP", False)):
+        if risk.clear_weekly_loss_cap(equity):
+            print(
+                f"[RISK] RESET_WEEKLY_LOSS_CAP applied at equity={float(equity):.2f}",
+                flush=True,
+            )
+        else:
+            print("[RISK] RESET_WEEKLY_LOSS_CAP requested but no weekly baseline changes were needed", flush=True)
 
 
 def _open_trades_state() -> List[Dict]:
@@ -916,12 +1022,17 @@ async def decision_cycle() -> None:
                 )
                 continue
 
+            adaptive_snap = _safe_adaptive_snapshot("decision_cycle")
+            effective_risk_pct = risk.risk_per_trade_pct
+            if adaptive_snap is not None:
+                effective_risk_pct = max(0.001, min(0.025, risk.risk_per_trade_pct * adaptive_snap.risk_multiplier))
+
             try:
                 size_result = position_sizer.units_for_risk(
                     equity,
                     evaluation.instrument,
                     sl_distance,
-                    risk.risk_per_trade_pct,
+                    effective_risk_pct,
                     broker=broker,
                     account_currency="AUD",
                     min_trade_units=1,
@@ -932,7 +1043,7 @@ async def decision_cycle() -> None:
                     equity,
                     entry_price or 0.0,
                     sl_distance,
-                    risk.risk_per_trade_pct,
+                    effective_risk_pct,
                 )
             if isinstance(size_result, tuple):
                 units, size_diag = size_result
@@ -940,8 +1051,8 @@ async def decision_cycle() -> None:
                 units = int(size_result)
                 size_diag = {
                     "equity": equity,
-                    "risk_pct": risk.risk_per_trade_pct,
-                    "risk_amount": equity * risk.risk_per_trade_pct,
+                    "risk_pct": effective_risk_pct,
+                    "risk_amount": equity * effective_risk_pct,
                     "stop_pips": 0.0,
                     "pip_value_per_unit": 0.0,
                     "final_units": units,
@@ -1069,5 +1180,67 @@ def launch_status_server_thread() -> threading.Thread:
     return thread
 
 if __name__ == "__main__":
+    journal_path = journal.path
+    journal_exists = journal_path.exists()
+    try:
+        trade_count = journal.count_trade_events()
+        print(
+            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} total_trades={trade_count}",
+            flush=True,
+        )
+    except Exception as exc:
+        print(
+            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} error={exc}",
+            flush=True,
+        )
+
+    print(
+        f"[RUNTIME] revision={_runtime_revision()} main={Path(__file__).resolve()}",
+        flush=True,
+    )
+    print(
+        f"[ADAPTIVE] module={adaptive_tuner.__class__.__module__} signature={_adaptive_snapshot_signature()}",
+        flush=True,
+    )
+
+    if _as_bool(os.getenv("RUN_PERFORMANCE_ANALYSIS", False)):
+        analysis_ready = False
+        for attempt in range(1, 6):
+            db_exists = journal.path.exists()
+            db_size = journal.path.stat().st_size if db_exists else 0
+            if db_exists and db_size > 0:
+                try:
+                    total_trades = journal.count_trade_events()
+                except Exception as exc:
+                    print(
+                        f"[MANUAL_ANALYSIS_WAIT] attempt={attempt} path={journal.path} error={exc}",
+                        flush=True,
+                    )
+                else:
+                    if total_trades > 0:
+                        analysis_ready = True
+                        break
+                    print(
+                        f"[MANUAL_ANALYSIS_WAIT] attempt={attempt} path={journal.path} total_trades={total_trades}",
+                        flush=True,
+                    )
+            else:
+                print(
+                    f"[MANUAL_ANALYSIS_WAIT] attempt={attempt} path={journal.path} exists={str(db_exists).lower()} size={db_size}",
+                    flush=True,
+                )
+            if attempt < 5:
+                time.sleep(1)
+
+        if not analysis_ready:
+            print("[MANUAL_ANALYSIS_ABORTED_NO_DB]", flush=True)
+        else:
+            print("[MANUAL_ANALYSIS_TRIGGERED]", flush=True)
+            run_performance_analysis(journal.path)
+            print("[MANUAL_ANALYSIS_COMPLETE]", flush=True)
+
+        if _as_bool(os.getenv("RUN_PERFORMANCE_ANALYSIS_ONLY", False)):
+            sys.exit(0)
+
     launch_status_server_thread()
     asyncio.run(runner())

--- a/src/profit_protection.py
+++ b/src/profit_protection.py
@@ -1125,6 +1125,11 @@ class ProfitProtection:
             except Exception:
                 equity_after = None
             try:
+                print(
+                    f"[TRADE_CLOSE_ATTEMPT] ticket={trade_id or 'n/a'} instrument={instrument} "
+                    f"pnl={float(summary.get('final_profit_ccy') or 0.0):.2f} reason={summary.get('reason') or 'n/a'}",
+                    flush=True,
+                )
                 self._journal.record_exit(
                     trade_id=str(trade_id or instrument or ""),
                     exit_timestamp_utc=now_val,
@@ -1141,9 +1146,19 @@ class ProfitProtection:
                     entry_price=state.entry_price if state else None,
                     equity_after=equity_after,
                 )
-            except Exception:
+                print(
+                    f"[TRADE_CLOSED] ticket={trade_id or 'n/a'} instrument={instrument} "
+                    f"pnl={float(summary.get('final_profit_ccy') or 0.0):.2f} "
+                    f"reason={summary.get('reason') or 'n/a'} duration_sec={int(summary.get('duration_sec') or 0)}",
+                    flush=True,
+                )
+            except Exception as exc:
                 # Journal failures must never block trade lifecycle.
-                pass
+                print(
+                    f"[JOURNAL][WARN] record_exit failed ticket={trade_id or 'n/a'} instrument={instrument} "
+                    f"reason={summary.get('reason') or 'n/a'} error={exc}",
+                    flush=True,
+                )
         if state:
             state.armed = False
             state.max_profit_ccy = None

--- a/src/risk_manager.py
+++ b/src/risk_manager.py
@@ -46,6 +46,12 @@ def _sanitize_equity(equity: Optional[float]) -> Optional[float]:
     return value
 
 
+def _as_bool(value: object) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "y"}
+    return bool(value)
+
+
 @dataclass
 class RiskState:
     day_id: Optional[str] = None
@@ -172,6 +178,7 @@ class RiskManager:
         self.risk_per_trade_pct = float(
             self.config.get("risk_per_trade_pct", 0.005)
         )
+        self._apply_env_risk_cap()
         env_max_positions = os.getenv("MAX_CONCURRENT_POSITIONS") or os.getenv("MAX_OPEN_TRADES")
         max_positions_cfg = self.config.get("max_concurrent_positions", self.config.get("max_open_trades", 3))
         self.max_concurrent_positions = int(env_max_positions or max_positions_cfg or 3)
@@ -226,6 +233,27 @@ class RiskManager:
         )
         self.equity_adjustment_pct = max(0.0, float(equity_adjustment_pct_cfg))
         self.equity_adjustment_abs = max(0.0, float(equity_adjustment_abs_cfg))
+
+    def _apply_env_risk_cap(self) -> None:
+        if not _as_bool(os.getenv("ENABLE_RISK_CAP", False)):
+            return
+        if _as_bool(os.getenv("ALLOW_HIGH_RISK", False)):
+            return
+
+        try:
+            cap_pct = float(os.getenv("MAX_RISK_PER_TRADE_CAP_PCT", "1.0")) / 100.0
+        except (TypeError, ValueError):
+            cap_pct = 0.01
+        cap_pct = max(0.001, min(cap_pct, 1.0))
+
+        original = float(self.risk_per_trade_pct)
+        capped = max(0.001, min(original, cap_pct))
+        if capped < original:
+            print(
+                f"[RISK] risk capped from {original*100:.1f}% to {capped*100:.1f}%",
+                flush=True,
+            )
+        self.risk_per_trade_pct = capped
 
     # ------------------------------------------------------------------
     # Persistence helpers
@@ -423,6 +451,44 @@ class RiskManager:
             f"[RISK] Loss streak pause active until {pause_until.isoformat()}",
             flush=True,
         )
+
+
+    def clear_weekly_loss_cap(self, equity: Optional[float] = None) -> bool:
+        """Reset weekly loss baseline so weekly-loss-cap no longer blocks entries."""
+        changed = False
+        if self.state.weekly_realized_pl != 0.0:
+            self.state.weekly_realized_pl = 0.0
+            changed = True
+
+        sanitized = _sanitize_equity(equity)
+        if sanitized is not None:
+            if self.state.week_start_equity != sanitized:
+                self.state.week_start_equity = sanitized
+                changed = True
+        elif self.state.week_start_equity is None and self._last_equity_seen is not None:
+            self.state.week_start_equity = self._last_equity_seen
+            changed = True
+
+        if self.state.has_hit_weekly_target:
+            self.state.has_hit_weekly_target = False
+            changed = True
+
+        if changed:
+            self._save_state()
+        return changed
+
+    def clear_max_drawdown_halt(self, equity: Optional[float] = None) -> bool:
+        """Clear max-drawdown halt and optionally re-anchor peak equity."""
+
+        valid_equity = _sanitize_equity(equity)
+        changed = bool(self.state.max_drawdown_halt)
+        self.state.max_drawdown_halt = False
+        if valid_equity is not None:
+            self.state.peak_equity = valid_equity
+            changed = True
+        if changed:
+            self._save_state()
+        return changed
 
     def startup_daily_reset(self, equity: Optional[float], *, open_positions_count: int = 0) -> None:
         """

--- a/src/trade_journal.py
+++ b/src/trade_journal.py
@@ -347,4 +347,263 @@ class TradeJournal:
             return int(row[0] if row else 0)
 
 
-__all__ = ["TradeJournal", "default_journal_path"]
+def _safe_div(numerator: float, denominator: float) -> float:
+    if denominator == 0:
+        return 0.0
+    return numerator / denominator
+
+
+def _compute_segment_metrics(trades: list[dict[str, Any]]) -> dict[str, float | int]:
+    total_trades = len(trades)
+    wins = [trade["pnl"] for trade in trades if trade["pnl"] > 0]
+    losses = [trade["pnl"] for trade in trades if trade["pnl"] < 0]
+
+    win_count = len(wins)
+    loss_count = len(losses)
+    win_rate_ratio = _safe_div(win_count, total_trades)
+    win_rate_pct = win_rate_ratio * 100.0
+
+    avg_win = _safe_div(sum(wins), win_count)
+    avg_loss = _safe_div(sum(losses), loss_count)
+
+    gross_profit = sum(wins)
+    gross_loss = sum(losses)
+    profit_factor = _safe_div(gross_profit, abs(gross_loss))
+    expectancy = (win_rate_ratio * avg_win) - ((1.0 - win_rate_ratio) * abs(avg_loss))
+
+    avg_trade_duration = _safe_div(
+        sum(float(trade.get("duration_seconds") or 0.0) for trade in trades),
+        total_trades,
+    )
+
+    return {
+        "total_trades": total_trades,
+        "wins": win_count,
+        "losses": loss_count,
+        "win_rate_pct": win_rate_pct,
+        "avg_win": avg_win,
+        "avg_loss": avg_loss,
+        "gross_profit": gross_profit,
+        "gross_loss": gross_loss,
+        "profit_factor": profit_factor,
+        "expectancy": expectancy,
+        "avg_trade_duration": avg_trade_duration,
+    }
+
+
+def _max_drawdown_and_losing_streak(trades: list[dict[str, Any]]) -> tuple[float, int]:
+    max_drawdown = 0.0
+    longest_losing_streak = 0
+    current_losing_streak = 0
+
+    peak_equity = 0.0
+    equity = 0.0
+
+    for trade in trades:
+        pnl = float(trade["pnl"])
+        equity += pnl
+        peak_equity = max(peak_equity, equity)
+        max_drawdown = max(max_drawdown, peak_equity - equity)
+
+        if pnl < 0:
+            current_losing_streak += 1
+            longest_losing_streak = max(longest_losing_streak, current_losing_streak)
+        else:
+            current_losing_streak = 0
+
+    return max_drawdown, longest_losing_streak
+
+
+def _format_performance_report(
+    *,
+    analysis_ts: datetime,
+    metrics: Mapping[str, float | int],
+    max_drawdown: float,
+    longest_losing_streak: int,
+    instrument_metrics: Mapping[str, Mapping[str, float | int]],
+) -> str:
+    lines = [
+        "Mossy 4X Performance Report",
+        f"Analysis UTC: {analysis_ts.isoformat()}",
+        "",
+        "[PERFORMANCE_SUMMARY]",
+        f"total_trades={metrics['total_trades']}",
+        f"win_rate={metrics['win_rate_pct']:.2f}",
+        f"wins={metrics['wins']}",
+        f"losses={metrics['losses']}",
+        f"avg_win={metrics['avg_win']:.2f}",
+        f"avg_loss={metrics['avg_loss']:.2f}",
+        f"gross_profit={metrics['gross_profit']:.2f}",
+        f"gross_loss={metrics['gross_loss']:.2f}",
+        f"profit_factor={metrics['profit_factor']:.4f}",
+        f"expectancy={metrics['expectancy']:.4f}",
+        f"max_drawdown={max_drawdown:.2f}",
+        f"longest_losing_streak={longest_losing_streak}",
+        f"avg_trade_duration={metrics['avg_trade_duration']:.2f}",
+        "",
+        "[PERFORMANCE_BY_INSTRUMENT]",
+    ]
+
+    for instrument in sorted(instrument_metrics.keys()):
+        segment = instrument_metrics[instrument]
+        lines.extend(
+            [
+                f"instrument={instrument}",
+                f"trades={segment['total_trades']}",
+                f"win_rate={segment['win_rate_pct']:.2f}",
+                f"avg_win={segment['avg_win']:.2f}",
+                f"avg_loss={segment['avg_loss']:.2f}",
+                f"expectancy={segment['expectancy']:.4f}",
+                f"profit_factor={segment['profit_factor']:.4f}",
+                "",
+            ]
+        )
+    return "\n".join(lines).strip()
+
+
+def _save_performance_pdf(report_text: str, analysis_ts: datetime, total_trades: int, report_dir: Path) -> Path:
+    timestamp_file = analysis_ts.strftime("%Y-%m-%dT%H-%M-%S")
+    filename = f"performance_{timestamp_file}_{int(total_trades)}trades.pdf"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    report_path = report_dir / filename
+
+    try:
+        from reportlab.lib.pagesizes import letter
+        from reportlab.pdfgen import canvas
+
+        pdf = canvas.Canvas(str(report_path), pagesize=letter)
+        _, height = letter
+        y = height - 60
+
+        pdf.setFont("Helvetica-Bold", 16)
+        pdf.drawString(40, y, "Mossy 4X Performance Report")
+        y -= 24
+        pdf.setFont("Helvetica", 11)
+        pdf.drawString(40, y, f"UTC timestamp: {analysis_ts.isoformat()}")
+        y -= 26
+
+        pdf.setFont("Courier", 9)
+        for line in report_text.splitlines():
+            if y < 50:
+                pdf.showPage()
+                y = height - 50
+                pdf.setFont("Courier", 9)
+            pdf.drawString(40, y, line)
+            y -= 12
+
+        pdf.setFont("Helvetica-Oblique", 8)
+        footer = f"Generated UTC: {datetime.now(timezone.utc).isoformat()}"
+        pdf.drawString(40, 28, footer)
+        pdf.save()
+        return report_path
+    except ModuleNotFoundError:
+        fallback_content = (
+            "%PDF-1.1\n"
+            "1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+            "2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj\n"
+            "3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>> >endobj\n"
+            f"4 0 obj<</Length {len(report_text) + 90}>>stream\n"
+            "BT /F1 10 Tf 40 760 Td (Mossy 4X Performance Report) Tj ET\n"
+            "endstream endobj\n"
+            "5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Courier>>endobj\n"
+            "xref\n0 6\n0000000000 65535 f \n"
+            "trailer<</Size 6/Root 1 0 R>>\nstartxref\n0\n%%EOF\n"
+        )
+        report_path.write_bytes(fallback_content.encode("utf-8", errors="ignore"))
+        return report_path
+
+
+
+def run_performance_analysis(db_path: Path | str | None = None) -> None:
+    """Compute and print performance analytics from all closed trades in trade_journal.db."""
+
+    db_file = Path(db_path) if db_path is not None else default_journal_path()
+    if not db_file.exists():
+        print(f"[PERFORMANCE_SUMMARY]\nerror=database_not_found\npath={db_file}", flush=True)
+        return
+
+    conn = sqlite3.connect(db_file)
+    try:
+        conn.row_factory = sqlite3.Row
+        rows = conn.execute(
+            """
+            SELECT
+                trade_id,
+                instrument,
+                COALESCE(realized_pnl_ccy, 0.0) AS pnl,
+                COALESCE(duration_seconds, 0) AS duration_seconds,
+                exit_timestamp_utc
+            FROM trades
+            WHERE exit_timestamp_utc IS NOT NULL
+            ORDER BY exit_timestamp_utc ASC, trade_id ASC
+            """
+        ).fetchall()
+    finally:
+        conn.close()
+
+    trades = [
+        {
+            "trade_id": row["trade_id"],
+            "instrument": (row["instrument"] or "UNKNOWN").upper(),
+            "pnl": float(row["pnl"] or 0.0),
+            "duration_seconds": int(row["duration_seconds"] or 0),
+        }
+        for row in rows
+    ]
+
+    metrics = _compute_segment_metrics(trades)
+    max_drawdown, longest_losing_streak = _max_drawdown_and_losing_streak(trades)
+
+    print("[PERFORMANCE_SUMMARY]", flush=True)
+    print(f"total_trades={metrics['total_trades']}", flush=True)
+    print(f"win_rate={metrics['win_rate_pct']:.2f}", flush=True)
+    print(f"wins={metrics['wins']}", flush=True)
+    print(f"losses={metrics['losses']}", flush=True)
+    print(f"avg_win={metrics['avg_win']:.2f}", flush=True)
+    print(f"avg_loss={metrics['avg_loss']:.2f}", flush=True)
+    print(f"gross_profit={metrics['gross_profit']:.2f}", flush=True)
+    print(f"gross_loss={metrics['gross_loss']:.2f}", flush=True)
+    print(f"profit_factor={metrics['profit_factor']:.4f}", flush=True)
+    print(f"expectancy={metrics['expectancy']:.4f}", flush=True)
+    print(f"max_drawdown={max_drawdown:.2f}", flush=True)
+    print(f"longest_losing_streak={longest_losing_streak}", flush=True)
+    print(f"avg_trade_duration={metrics['avg_trade_duration']:.2f}", flush=True)
+
+    by_instrument: dict[str, list[dict[str, Any]]] = {}
+    for trade in trades:
+        by_instrument.setdefault(trade["instrument"], []).append(trade)
+
+    instrument_metrics: dict[str, dict[str, float | int]] = {}
+    print("\n[PERFORMANCE_BY_INSTRUMENT]", flush=True)
+    for instrument in sorted(by_instrument.keys()):
+        segment_metrics = _compute_segment_metrics(by_instrument[instrument])
+        instrument_metrics[instrument] = segment_metrics
+        print(f"instrument={instrument}", flush=True)
+        print(f"trades={segment_metrics['total_trades']}", flush=True)
+        print(f"win_rate={segment_metrics['win_rate_pct']:.2f}", flush=True)
+        print(f"avg_win={segment_metrics['avg_win']:.2f}", flush=True)
+        print(f"avg_loss={segment_metrics['avg_loss']:.2f}", flush=True)
+        print(f"expectancy={segment_metrics['expectancy']:.4f}", flush=True)
+        print(f"profit_factor={segment_metrics['profit_factor']:.4f}", flush=True)
+        print("", flush=True)
+
+    analysis_ts = datetime.now(timezone.utc)
+    report_text = _format_performance_report(
+        analysis_ts=analysis_ts,
+        metrics=metrics,
+        max_drawdown=max_drawdown,
+        longest_losing_streak=longest_losing_streak,
+        instrument_metrics=instrument_metrics,
+    )
+
+    report_dir = Path(os.getenv("PERFORMANCE_REPORT_DIR", "/var/data/performance_reports/"))
+    report_path = _save_performance_pdf(
+        report_text=report_text,
+        analysis_ts=analysis_ts,
+        total_trades=int(metrics["total_trades"]),
+        report_dir=report_dir,
+    )
+    print(f"[PERFORMANCE_PDF_SAVED] path={report_path.resolve()}", flush=True)
+
+
+__all__ = ["TradeJournal", "default_journal_path", "run_performance_analysis"]

--- a/tests/test_adaptive_tuner.py
+++ b/tests/test_adaptive_tuner.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from src.adaptive_tuner import AdaptiveTuner
+
+
+def _make_db(path: Path, trade_pnl: list[float], event_pnl: list[float] | None = None) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE trades (
+                trade_id TEXT,
+                exit_timestamp_utc TEXT,
+                realized_pnl_ccy REAL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE trade_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                timestamp TEXT,
+                instrument TEXT,
+                direction TEXT,
+                entry_price REAL,
+                exit_price REAL,
+                profit REAL,
+                reason TEXT,
+                equity_after REAL
+            )
+            """
+        )
+        for idx, pnl in enumerate(trade_pnl, start=1):
+            conn.execute(
+                "INSERT INTO trades(trade_id, exit_timestamp_utc, realized_pnl_ccy) VALUES (?, datetime('now'), ?)",
+                (str(idx), pnl),
+            )
+        for idx, pnl in enumerate(event_pnl or [], start=1):
+            conn.execute(
+                "INSERT INTO trade_events(timestamp, instrument, direction, entry_price, exit_price, profit, reason, equity_after) "
+                "VALUES (datetime('now'), 'EUR_USD', 'BUY', 1.1, 1.2, ?, 'TRAIL', 1000)",
+                (pnl,),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_adaptive_tuner_reduces_risk_on_loss_streak(tmp_path):
+    db = tmp_path / "journal.db"
+    _make_db(db, [-1.0, -2.0, -0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+
+    snap = AdaptiveTuner(db, lookback=10, min_sample=8).snapshot()
+    assert snap.closed_trades == 10
+    assert snap.loss_streak == 3
+    assert snap.risk_multiplier == 0.6
+    assert snap.source == "trades"
+
+
+def test_adaptive_tuner_uses_conservative_mode_with_small_sample(tmp_path):
+    db = tmp_path / "journal.db"
+    _make_db(db, [1.0, -1.0, 1.0])
+
+    snap = AdaptiveTuner(db, lookback=40, min_sample=8).snapshot()
+    assert snap.closed_trades == 3
+    assert snap.risk_multiplier == 0.85
+    assert snap.source == "trades"
+
+
+def test_adaptive_tuner_falls_back_to_trade_events_when_trades_unavailable(tmp_path):
+    db = tmp_path / "journal.db"
+    _make_db(db, [], event_pnl=[-2.0, -1.0, 1.5, 0.5, -0.2])
+
+    snap = AdaptiveTuner(db, lookback=10, min_sample=8).snapshot()
+    assert snap.closed_trades == 5
+    assert snap.source == "trade_events"

--- a/tests/test_beast_mode.py
+++ b/tests/test_beast_mode.py
@@ -32,7 +32,8 @@ def test_beast_mode_forces_always_session(monkeypatch):
 
     assert main_mod.config["aggressive_test_mode"] is True
     assert main_mod.config["session_mode"] == "ALWAYS"
-    assert main_mod.config["risk"]["risk_per_trade_pct"] == 0.025
+    # In aggressive test mode, risk cap defaults to enabled unless explicitly overridden.
+    assert main_mod.config["risk"]["risk_per_trade_pct"] == 0.01
     assert main_mod.config["risk"]["daily_profit_target_usd"] == 0.0
 
     decision = session_filter.session_decision(

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -329,7 +329,10 @@ def test_max_concurrent_positions_default_and_env_override(monkeypatch, state_di
     assert reason == "max-positions"
 
 
-def test_daily_trade_cap_blocks_and_resets(state_dir):
+def test_daily_trade_cap_blocks_and_resets(monkeypatch, state_dir):
+    monkeypatch.delenv("MAX_TRADES_PER_DAY", raising=False)
+    monkeypatch.setenv("MINI_RUN_MAX_TRADES_PER_DAY", "100")
+
     manager = RiskManager({"max_trades_per_day": 2}, mode="paper")
     now = _utc(2024, 1, 1, 9, 0)
 
@@ -355,3 +358,49 @@ def test_aggressive_test_mode_bypasses_mini_run_trade_soft_cap(monkeypatch, stat
     )
 
     assert manager.max_trades_per_day == 100
+
+
+def test_clear_max_drawdown_halt_reanchors_peak_equity(state_dir):
+    manager = RiskManager({"max_drawdown_cap_pct": 0.1}, mode="paper")
+    now = _utc(2024, 1, 1, 0, 0)
+
+    manager.should_open(now, 1_000.0, [], "EUR_USD", 0.1)
+    manager.state.max_drawdown_halt = True
+    manager.state.peak_equity = 1_000.0
+
+    changed = manager.clear_max_drawdown_halt(850.0)
+    assert changed is True
+    assert manager.state.max_drawdown_halt is False
+    assert manager.state.peak_equity == pytest.approx(850.0)
+
+    ok, reason = manager.should_open(now + timedelta(minutes=2), 850.0, [], "EUR_USD", 0.1)
+    assert ok is True
+    assert reason == "ok"
+
+
+def test_clear_max_drawdown_halt_without_equity_noop_when_not_halted(state_dir):
+    manager = RiskManager({}, mode="paper")
+    changed = manager.clear_max_drawdown_halt()
+    assert changed is False
+    assert manager.state.max_drawdown_halt is False
+
+
+def test_clear_weekly_loss_cap_reanchors_and_allows_entries(state_dir):
+    manager = RiskManager({"weekly_loss_cap_pct": 0.03, "daily_loss_cap_pct": 1.0}, mode="paper")
+    now = _utc(2024, 1, 1, 0, 0)
+
+    manager.should_open(now, 1_000.0, [], "EUR_USD", 0.1)
+
+    blocked_now = now + timedelta(minutes=10)
+    ok, reason = manager.should_open(blocked_now, 960.0, [], "EUR_USD", 0.1)
+    assert ok is False
+    assert reason == "weekly-loss-cap"
+
+    changed = manager.clear_weekly_loss_cap(960.0)
+    assert changed is True
+    assert manager.state.week_start_equity == pytest.approx(960.0)
+    assert manager.state.weekly_realized_pl == pytest.approx(0.0)
+
+    ok, reason = manager.should_open(blocked_now + timedelta(minutes=1), 960.0, [], "EUR_USD", 0.1)
+    assert ok is True
+    assert reason == "ok"

--- a/tests/test_trade_journal.py
+++ b/tests/test_trade_journal.py
@@ -75,3 +75,48 @@ def test_trade_journal_entry_and_exit(tmp_path):
         assert event_count == 2
 
     assert journal.count_trade_events() == 2
+
+
+
+def test_run_performance_analysis_creates_pdf(tmp_path, monkeypatch):
+    from src.trade_journal import run_performance_analysis
+
+    db_path = tmp_path / "journal.db"
+    report_dir = tmp_path / "reports"
+    monkeypatch.setenv("PERFORMANCE_REPORT_DIR", str(report_dir))
+
+    journal = TradeJournal(db_path)
+    entry_ts = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    journal.record_entry(
+        trade_id="T-PDF-1",
+        timestamp_utc=entry_ts,
+        instrument="EUR_USD",
+        side="BUY",
+        units=1000,
+        entry_price=1.2345,
+        stop_loss_price=1.2300,
+        take_profit_price=1.2400,
+        spread_at_entry=0.12,
+        session_id="LONDON",
+        session_mode="STRICT",
+        run_tag="MINI_RUN",
+        gating_flags={"session_ok": True},
+        indicators_snapshot={"rsi": 55.5},
+    )
+    journal.record_exit(
+        trade_id="T-PDF-1",
+        exit_timestamp_utc=entry_ts + timedelta(minutes=20),
+        exit_price=1.2375,
+        spread_at_exit=0.15,
+        max_profit_ccy=3.0,
+        realized_pnl_ccy=2.5,
+        exit_reason="TP",
+        duration_seconds=1200,
+        broker_confirmed=True,
+    )
+
+    run_performance_analysis(db_path)
+    run_performance_analysis(db_path)
+
+    pdf_files = list(report_dir.glob("performance_*trades.pdf"))
+    assert pdf_files, "Expected a generated PDF report"


### PR DESCRIPTION
### Motivation
- Provide an opt-in read-only adaptive position sizing helper to reduce risk after recent losing streaks and adjust effective per-trade risk dynamically.
- Add configurable risk-cap enforcement to prevent inadvertent high-per-trade sizing in aggressive/demo configurations.
- Offer a commandable performance analysis tool that summarizes closed trades and emits a PDF report for manual inspection.
- Improve operational observability around trade closes, runtime revision, adaptive snapshot signature, and journal errors to aid diagnostics.

### Description
- Add `src/adaptive_tuner.py` implementing `AdaptiveTuner` and `AdaptiveSnapshot` with DB-backed lookback logic and conservative multipliers, and wire an `adaptive_tuner` instance into `src/main.py` using env vars `ADAPTIVE_LOOKBACK`, `ADAPTIVE_MIN_SAMPLE`, and `ADAPTIVE_TUNING_ENABLED`.
- Introduce safe adaptive snapshot usage in live flows (`_safe_adaptive_snapshot`) and apply the snapshot multiplier when computing effective risk used by `position_sizer` in the decision path.
- Implement risk-cap functionality with `_clamp_risk_pct` and `ENABLE_RISK_CAP` / `MAX_RISK_PER_TRADE_CAP_PCT` / `ALLOW_HIGH_RISK` semantics and apply it both at startup config composition and inside `RiskManager` via `_apply_env_risk_cap`.
- Enhance logging around runtime revision (`_runtime_revision`), adaptive snapshot signature (`_adaptive_snapshot_signature`), trade close attempts and journal failures in `profit_protection.py`, and add environment-driven reset hooks (`RESET_MAX_DRAWDOWN_HALT`, `RESET_WEEKLY_LOSS_CAP`).
- Extend `src/trade_journal.py` with `run_performance_analysis` that computes performance metrics, per-instrument breakdown, max drawdown / losing streak, formats a textual report and attempts to save a PDF (using `reportlab` if available, otherwise writing a fallback PDF blob), and export it via `__all__`.
- Add `reportlab` to `requirements.txt` and add/adjust environment-driven behavior flags such as `AGGRESSIVE_TEST_RISK_PCT`, `RUN_PERFORMANCE_ANALYSIS`, `RUN_PERFORMANCE_ANALYSIS_ONLY`, and `PERFORMANCE_REPORT_DIR`.
- Add unit tests: `tests/test_adaptive_tuner.py` and update existing tests (`tests/test_beast_mode.py`, `tests/test_risk_manager.py`, `tests/test_trade_journal.py`) to cover the new adaptive tuning, risk cap defaults, clearing halts, and PDF generation.

### Testing
- Ran the test suite with `pytest` including the new `tests/test_adaptive_tuner.py` and updated tests for risk and journal behavior, and all tests completed successfully.
- Exercised `run_performance_analysis` in tests to verify a PDF report is created to `PERFORMANCE_REPORT_DIR` (uses `reportlab` when available and falls back to a minimal PDF blob otherwise).
- Verified adaptive snapshot is produced from either `trades` or `trade_events` DB tables and that the snapshot path is resilient to missing DB and older `AdaptiveSnapshot` signatures via compatibility handling.
- Confirmed risk cap logic reduces `risk_per_trade_pct` when `ENABLE_RISK_CAP` is set and `ALLOW_HIGH_RISK` is not set, and that `clear_max_drawdown_halt` / `clear_weekly_loss_cap` behaviors are covered by unit tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e6574c7148329a1b359a23a979bb5)