### PR TITLE
Reset max_drawdown_halt on daily rollover and add simple performance PDF export

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .

--- a/src/risk_manager.py
+++ b/src/risk_manager.py
@@ -573,6 +573,8 @@ class RiskManager:
             self.state.day_start_equity = valid_equity
             self.state.daily_realized_pl = 0.0
             self.state.loss_streak_pause_until = None
+            if self.state.max_drawdown_halt:
+                self.state.max_drawdown_halt = False
             if prev_day_id is not None:
                 self.state.daily_entry_count = 0
             changed = True

--- a/src/trade_journal.py
+++ b/src/trade_journal.py
@@ -414,6 +414,53 @@ def _max_drawdown_and_losing_streak(trades: list[dict[str, Any]]) -> tuple[float
     return max_drawdown, longest_losing_streak
 
 
+def _write_performance_pdf(report_dir: Path, total_trades: int) -> Path:
+    """Write a tiny single-page PDF summary artifact and return its path."""
+
+    report_dir.mkdir(parents=True, exist_ok=True)
+    output = report_dir / f"performance_{total_trades}trades.pdf"
+    lines = ("Performance Summary", f"Total trades: {total_trades}")
+    text_ops = [
+        "BT",
+        "/F1 14 Tf",
+        "72 740 Td",
+    ]
+    for i, line in enumerate(lines):
+        escaped = line.replace("\\", "\\\\").replace("(", "\\(").replace(")", "\\)")
+        if i > 0:
+            text_ops.append("0 -20 Td")
+        text_ops.append(f"({escaped}) Tj")
+    text_ops.append("ET")
+    stream = ("\n".join(text_ops) + "\n").encode("latin-1", errors="replace")
+
+    objects = [
+        b"1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n",
+        b"2 0 obj << /Type /Pages /Kids [3 0 R] /Count 1 >> endobj\n",
+        b"3 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >> endobj\n",
+        f"4 0 obj << /Length {len(stream)} >> stream\n".encode("ascii") + stream + b"endstream endobj\n",
+        b"5 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n",
+    ]
+
+    header = b"%PDF-1.4\n"
+    body = bytearray(header)
+    offsets = [0]
+    for obj in objects:
+        offsets.append(len(body))
+        body.extend(obj)
+
+    xref_pos = len(body)
+    count = len(objects) + 1
+    body.extend(f"xref\n0 {count}\n".encode("ascii"))
+    body.extend(b"0000000000 65535 f \n")
+    for off in offsets[1:]:
+        body.extend(f"{off:010d} 00000 n \n".encode("ascii"))
+    body.extend(
+        f"trailer << /Size {count} /Root 1 0 R >>\nstartxref\n{xref_pos}\n%%EOF\n".encode("ascii")
+    )
+
+    output.write_bytes(bytes(body))
+    return output
+
 def run_performance_analysis(db_path: Path | str | None = None) -> None:
     """Compute and print performance analytics from all closed trades in trade_journal.db."""
 
@@ -468,6 +515,10 @@ def run_performance_analysis(db_path: Path | str | None = None) -> None:
     print(f"max_drawdown={max_drawdown:.2f}", flush=True)
     print(f"longest_losing_streak={longest_losing_streak}", flush=True)
     print(f"avg_trade_duration={metrics['avg_trade_duration']:.2f}", flush=True)
+
+    if metrics["total_trades"] > 0:
+        report_root = Path(os.getenv("PERFORMANCE_REPORT_DIR", "reports"))
+        _write_performance_pdf(report_root, metrics["total_trades"])
 
     by_instrument: dict[str, list[dict[str, Any]]] = {}
     for trade in trades:

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -285,6 +285,26 @@ def test_rollover_preserves_realized_pl_when_equity_missing(state_dir):
     assert manager.state.daily_realized_pl == pytest.approx(0.0)
 
 
+
+
+def test_max_drawdown_halt_resets_on_new_day(state_dir):
+    manager = RiskManager({"max_drawdown_cap_pct": 0.10, "daily_loss_cap_pct": 1.0, "weekly_loss_cap_pct": 1.0}, mode="paper")
+    now = _utc(2024, 1, 1, 0, 0)
+
+    manager.should_open(now, 1_000.0, [], "EUR_USD", 0.2)
+    manager.enforce_equity_floor(now + timedelta(minutes=5), 890.0, close_all_cb=lambda: None)
+
+    blocked, reason = manager.should_open(now + timedelta(minutes=6), 890.0, [], "EUR_USD", 0.2)
+    assert blocked is False
+    assert reason == "max-drawdown"
+    assert manager.state.max_drawdown_halt is True
+
+    next_day = now + timedelta(days=1)
+    ok, reason = manager.should_open(next_day, 1_000.0, [], "EUR_USD", 0.2)
+    assert ok is True
+    assert reason == "ok"
+    assert manager.state.max_drawdown_halt is False
+
 def test_default_atr_multipliers_are_applied(state_dir):
     manager = RiskManager({}, mode="paper")
 

--- a/tests/test_trade_journal.py
+++ b/tests/test_trade_journal.py
@@ -120,3 +120,37 @@ def test_run_performance_analysis_creates_pdf(tmp_path, monkeypatch):
 
     pdf_files = list(report_dir.glob("performance_*trades.pdf"))
     assert pdf_files, "Expected a generated PDF report"
+    pdf_data = pdf_files[0].read_bytes()
+    assert pdf_data.startswith(b"%PDF-1.4")
+    assert b"(Total trades: 1) Tj" in pdf_data
+
+
+def test_run_performance_analysis_skips_pdf_when_no_closed_trades(tmp_path, monkeypatch):
+    from src.trade_journal import run_performance_analysis
+
+    db_path = tmp_path / "journal.db"
+    report_dir = tmp_path / "reports"
+    monkeypatch.setenv("PERFORMANCE_REPORT_DIR", str(report_dir))
+
+    journal = TradeJournal(db_path)
+    entry_ts = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    journal.record_entry(
+        trade_id="T-PDF-OPEN",
+        timestamp_utc=entry_ts,
+        instrument="EUR_USD",
+        side="BUY",
+        units=1000,
+        entry_price=1.2345,
+        stop_loss_price=1.2300,
+        take_profit_price=1.2400,
+        spread_at_entry=0.12,
+        session_id="LONDON",
+        session_mode="STRICT",
+        run_tag="MINI_RUN",
+        gating_flags={"session_ok": True},
+        indicators_snapshot={"rsi": 55.5},
+    )
+
+    run_performance_analysis(db_path)
+
+    assert not list(report_dir.glob("performance_*trades.pdf"))


### PR DESCRIPTION
### Motivation
- Ensure the `max_drawdown_halt` state is cleared at the start of a new trading day so resumes are allowed after a day boundary.
- Emit a minimal performance PDF summary when running performance analysis to provide a lightweight artifact for CI or local inspection.

### Description
- Added `pytest.ini` with `pythonpath = .` to ensure test imports resolve correctly.
- Reset `self.state.max_drawdown_halt` to `False` in `RiskManager._rollover` when a new day starts so the halt does not persist indefinitely.
- Implemented `_write_performance_pdf(report_dir, total_trades)` in `src/trade_journal.py` to produce a tiny single-page PDF (raw PDF objects, Helvetica text) and return the file path.
- Updated `run_performance_analysis` to write the PDF when `metrics['total_trades'] > 0` using the `PERFORMANCE_REPORT_DIR` environment variable with a default of `reports`.
- Added tests to verify the rollover behavior and PDF generation/skip logic in `tests/test_risk_manager.py` and `tests/test_trade_journal.py`.

### Testing
- Ran the updated unit tests including `tests/test_risk_manager.py::test_max_drawdown_halt_resets_on_new_day` and they passed.
- Ran `tests/test_trade_journal.py::test_run_performance_analysis_creates_pdf` which confirmed a generated PDF starting with `%PDF-1.4` and containing the expected text, and the test passed.
- Ran `tests/test_trade_journal.py::test_run_performance_analysis_skips_pdf_when_no_closed_trades` which confirmed no PDF is created when there are no closed trades, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb85ee9288329a9ed0d7028c61720)