### PR TITLE
Make trading summary unambiguous: explicit lifetime/session counters and adaptive filter metadata

### DIFF
--- a/src/adaptive_tuner.py
+++ b/src/adaptive_tuner.py
@@ -3,37 +3,63 @@ from __future__ import annotations
 import inspect
 import sqlite3
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
+from typing import Optional
 
 
 @dataclass
 class AdaptiveSnapshot:
-    closed_trades: int
+    lifetime_closed_trades: int
+    session_closed_trades: int
     wins: int
     losses: int
     loss_streak: int
     risk_multiplier: float
     source: str = "none"
+    filter_run_tag: str = "all"
+    filter_window_start_utc: str = "none"
+    filter_window_end_utc: str = "none"
 
 
 class AdaptiveTuner:
     """Read-only adaptive sizing helper based on recent closed-trade outcomes."""
 
-    def __init__(self, db_path: Path, *, lookback: int = 40, min_sample: int = 10) -> None:
+    def __init__(
+        self,
+        db_path: Path,
+        *,
+        lookback: int = 40,
+        min_sample: int = 10,
+        run_tag: Optional[str] = None,
+        window_start_utc: Optional[str] = None,
+    ) -> None:
         self.db_path = Path(db_path)
         self.lookback = max(10, int(lookback))
         self.min_sample = max(3, int(min_sample))
+        self.run_tag = (run_tag or "").strip() or None
+        self.window_start_utc = (window_start_utc or "").strip() or None
 
     def _load_recent_pnl_from_trades(self, conn: sqlite3.Connection) -> list[float]:
+        columns = self._trade_columns(conn)
+        params: list[object] = []
+        predicates = ["exit_timestamp_utc IS NOT NULL"]
+        if self.run_tag and "run_tag" in columns:
+            predicates.append("run_tag = ?")
+            params.append(self.run_tag)
+        if self.window_start_utc:
+            predicates.append("exit_timestamp_utc >= ?")
+            params.append(self.window_start_utc)
+
         rows = conn.execute(
-            """
+            f"""
             SELECT COALESCE(realized_pnl_ccy, 0.0) AS pnl
             FROM trades
-            WHERE exit_timestamp_utc IS NOT NULL
+            WHERE {' AND '.join(predicates)}
             ORDER BY exit_timestamp_utc DESC
             LIMIT ?
             """,
-            (self.lookback,),
+            (*params, self.lookback),
         ).fetchall()
         return [float(row[0] or 0.0) for row in rows]
 
@@ -68,6 +94,33 @@ class AdaptiveTuner:
         finally:
             conn.close()
 
+    def _count_trades(self, conn: sqlite3.Connection) -> tuple[int, int]:
+        columns = self._trade_columns(conn)
+        lifetime_row = conn.execute(
+            "SELECT COUNT(*) FROM trades WHERE exit_timestamp_utc IS NOT NULL"
+        ).fetchone()
+        lifetime = int(lifetime_row[0] if lifetime_row else 0)
+
+        params: list[object] = []
+        predicates = ["exit_timestamp_utc IS NOT NULL"]
+        if self.run_tag and "run_tag" in columns:
+            predicates.append("run_tag = ?")
+            params.append(self.run_tag)
+        if self.window_start_utc:
+            predicates.append("exit_timestamp_utc >= ?")
+            params.append(self.window_start_utc)
+        session_row = conn.execute(
+            f"SELECT COUNT(*) FROM trades WHERE {' AND '.join(predicates)}",
+            params,
+        ).fetchone()
+        session = int(session_row[0] if session_row else 0)
+        return lifetime, session
+
+    @staticmethod
+    def _trade_columns(conn: sqlite3.Connection) -> set[str]:
+        rows = conn.execute("PRAGMA table_info(trades)").fetchall()
+        return {str(row[1]) for row in rows if len(row) > 1}
+
     @staticmethod
     def _loss_streak(recent_desc: list[float]) -> int:
         streak = 0
@@ -80,19 +133,35 @@ class AdaptiveTuner:
 
 
     @staticmethod
-    def _build_snapshot(*, closed_trades: int, wins: int, losses: int, loss_streak: int, risk_multiplier: float, source: str) -> AdaptiveSnapshot:
+    def _build_snapshot(
+        *,
+        lifetime_closed_trades: int,
+        session_closed_trades: int,
+        wins: int,
+        losses: int,
+        loss_streak: int,
+        risk_multiplier: float,
+        source: str,
+        filter_run_tag: str,
+        filter_window_start_utc: str,
+        filter_window_end_utc: str,
+    ) -> AdaptiveSnapshot:
         """Build snapshot compatibly across mixed deployments.
 
         Some environments may still have an older AdaptiveSnapshot signature
         without the ``source`` field when stale bytecode is loaded.
         """
         payload = {
-            "closed_trades": closed_trades,
+            "lifetime_closed_trades": lifetime_closed_trades,
+            "session_closed_trades": session_closed_trades,
             "wins": wins,
             "losses": losses,
             "loss_streak": loss_streak,
             "risk_multiplier": risk_multiplier,
             "source": source,
+            "filter_run_tag": filter_run_tag,
+            "filter_window_start_utc": filter_window_start_utc,
+            "filter_window_end_utc": filter_window_end_utc,
         }
         try:
             return AdaptiveSnapshot(**payload)
@@ -103,16 +172,25 @@ class AdaptiveTuner:
 
     def snapshot(self) -> AdaptiveSnapshot:
         recent, source = self._load_recent_pnl()
-        closed = len(recent)
+        session_closed = len(recent)
         wins = sum(1 for pnl in recent if pnl > 0)
         losses = sum(1 for pnl in recent if pnl < 0)
         loss_streak = self._loss_streak(recent)
+        filter_window_end_utc = datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+        lifetime_closed = 0
+        if self.db_path.exists():
+            conn = sqlite3.connect(self.db_path)
+            try:
+                lifetime_closed, _ = self._count_trades(conn)
+            finally:
+                conn.close()
 
         # Fast-start conservative mode until sufficient sample is available.
-        if closed < self.min_sample:
+        if session_closed < self.min_sample:
             multiplier = 0.85
         else:
-            win_rate = wins / closed if closed else 0.0
+            win_rate = wins / session_closed if session_closed else 0.0
             if loss_streak >= 3:
                 multiplier = 0.6
             elif loss_streak >= 2:
@@ -125,10 +203,14 @@ class AdaptiveTuner:
                 multiplier = 0.9
 
         return self._build_snapshot(
-            closed_trades=closed,
+            lifetime_closed_trades=lifetime_closed,
+            session_closed_trades=session_closed,
             wins=wins,
             losses=losses,
             loss_streak=loss_streak,
             risk_multiplier=max(0.5, min(1.0, multiplier)),
             source=source,
+            filter_run_tag=self.run_tag or "all",
+            filter_window_start_utc=self.window_start_utc or "none",
+            filter_window_end_utc=filter_window_end_utc,
         )

--- a/src/main.py
+++ b/src/main.py
@@ -75,15 +75,27 @@ from src.risk_setup import (
 from src.trade_journal import TradeJournal, default_journal_path, run_performance_analysis
 
 VERSION = "v1.6.1"
+STARTUP_UTC = datetime.now(timezone.utc)
 
 CONFIG_PATH = Path(__file__).resolve().parent.parent / "config" / "defaults.json"
 DEFAULT_DATA_DIR = Path(__file__).resolve().parent.parent / "data"
 DATA_DIR = resolve_state_dir(DEFAULT_DATA_DIR)
 journal = TradeJournal(default_journal_path(DATA_DIR))
+
+
+def _adaptive_window_start_utc() -> str:
+    now = datetime.now(timezone.utc)
+    day_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    window_start = max(day_start, STARTUP_UTC.replace(microsecond=0))
+    return window_start.isoformat()
+
+
 adaptive_tuner = AdaptiveTuner(
     journal.path,
     lookback=int(os.getenv("ADAPTIVE_LOOKBACK", 40)),
     min_sample=int(os.getenv("ADAPTIVE_MIN_SAMPLE", 8)),
+    run_tag=os.getenv("ADAPTIVE_RUN_TAG", "MINI_RUN"),
+    window_start_utc=os.getenv("ADAPTIVE_WINDOW_START_UTC", _adaptive_window_start_utc()),
 )
 MINI_RUN_TAG = "MINI_RUN"
 
@@ -110,6 +122,19 @@ def _adaptive_snapshot_signature() -> str:
         return ",".join(params)
     except Exception:
         return "unavailable"
+
+
+def _format_trading_summary(snapshot) -> str:
+    return (
+        f"source={snapshot.source} "
+        f"lifetime_closed_trades={snapshot.lifetime_closed_trades} "
+        f"session_closed_trades={snapshot.session_closed_trades} "
+        f"wins={snapshot.wins} losses={snapshot.losses} "
+        f"loss_streak={snapshot.loss_streak} risk_mult={snapshot.risk_multiplier:.2f} "
+        f"run_tag={snapshot.filter_run_tag} "
+        f"window_start_utc={snapshot.filter_window_start_utc} "
+        f"window_end_utc={snapshot.filter_window_end_utc}"
+    )
 
 
 def load_config(path: Path = CONFIG_PATH) -> Dict:
@@ -487,17 +512,27 @@ async def heartbeat() -> None:
 
     journal_path = journal.path
     journal_exists = journal_path.exists()
-    try:
-        trade_count = journal.count_trade_events()
+    snap = _safe_adaptive_snapshot("heartbeat")
+    if snap is not None:
         print(
-            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} total_trades={trade_count}",
+            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} "
+            f"lifetime_closed_trades={snap.lifetime_closed_trades} "
+            f"session_closed_trades={snap.session_closed_trades}",
             flush=True,
         )
-    except Exception as exc:
-        print(
-            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} error={exc}",
-            flush=True,
-        )
+    else:
+        try:
+            trade_count = journal.count_trade_events()
+            print(
+                f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} "
+                f"lifetime_closed_trades={trade_count} session_closed_trades={trade_count}",
+                flush=True,
+            )
+        except Exception as exc:
+            print(
+                f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} error={exc}",
+                flush=True,
+            )
 
     print(
         f"[RUNTIME] revision={_runtime_revision()} main={Path(__file__).resolve()}",
@@ -522,13 +557,12 @@ async def heartbeat() -> None:
         f"{ts_local} equity={equity:.2f} open_trades={open_count}",
     )
 
-    snap = _safe_adaptive_snapshot("heartbeat")
     if snap is not None:
         log_cycle_event(
             "INFO",
             cycle_context,
             "TRADING_SUMMARY",
-            f"source={snap.source} closed={snap.closed_trades} wins={snap.wins} losses={snap.losses} loss_streak={snap.loss_streak} risk_mult={snap.risk_multiplier:.2f}",
+            _format_trading_summary(snap),
         )
 
 suppression_counters = {
@@ -582,6 +616,16 @@ def _startup_checks() -> None:
         open_count = 0
 
     risk.startup_daily_reset(equity, open_positions_count=open_count)
+    snap = _safe_adaptive_snapshot("startup")
+    if snap is not None:
+        print(
+            "[JOURNAL][STARTUP] "
+            f"lifetime_closed_trades={snap.lifetime_closed_trades} "
+            f"session_closed_trades={snap.session_closed_trades} "
+            f"source={snap.source} run_tag={snap.filter_run_tag} "
+            f"window_start_utc={snap.filter_window_start_utc} window_end_utc={snap.filter_window_end_utc}",
+            flush=True,
+        )
 
     if _as_bool(os.getenv("RESET_MAX_DRAWDOWN_HALT", False)):
         if risk.clear_max_drawdown_halt(equity):
@@ -1324,10 +1368,17 @@ def launch_status_server_thread() -> threading.Thread:
 if __name__ == "__main__":
     journal_path = journal.path
     journal_exists = journal_path.exists()
+    startup_snap = _safe_adaptive_snapshot("main_boot")
     try:
-        trade_count = journal.count_trade_events()
+        if startup_snap is not None:
+            trade_count = startup_snap.lifetime_closed_trades
+            session_count = startup_snap.session_closed_trades
+        else:
+            trade_count = journal.count_trade_events()
+            session_count = trade_count
         print(
-            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} total_trades={trade_count}",
+            f"[JOURNAL] path={journal_path} exists={str(journal_exists).lower()} "
+            f"lifetime_closed_trades={trade_count} session_closed_trades={session_count}",
             flush=True,
         )
     except Exception as exc:

--- a/tests/test_adaptive_tuner.py
+++ b/tests/test_adaptive_tuner.py
@@ -54,7 +54,8 @@ def test_adaptive_tuner_reduces_risk_on_loss_streak(tmp_path):
     _make_db(db, [-1.0, -2.0, -0.5, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
 
     snap = AdaptiveTuner(db, lookback=10, min_sample=8).snapshot()
-    assert snap.closed_trades == 10
+    assert snap.lifetime_closed_trades == 10
+    assert snap.session_closed_trades == 10
     assert snap.loss_streak == 3
     assert snap.risk_multiplier == 0.6
     assert snap.source == "trades"
@@ -65,7 +66,8 @@ def test_adaptive_tuner_uses_conservative_mode_with_small_sample(tmp_path):
     _make_db(db, [1.0, -1.0, 1.0])
 
     snap = AdaptiveTuner(db, lookback=40, min_sample=8).snapshot()
-    assert snap.closed_trades == 3
+    assert snap.lifetime_closed_trades == 3
+    assert snap.session_closed_trades == 3
     assert snap.risk_multiplier == 0.85
     assert snap.source == "trades"
 
@@ -75,5 +77,6 @@ def test_adaptive_tuner_falls_back_to_trade_events_when_trades_unavailable(tmp_p
     _make_db(db, [], event_pnl=[-2.0, -1.0, 1.5, 0.5, -0.2])
 
     snap = AdaptiveTuner(db, lookback=10, min_sample=8).snapshot()
-    assert snap.closed_trades == 5
+    assert snap.lifetime_closed_trades == 0
+    assert snap.session_closed_trades == 5
     assert snap.source == "trade_events"

--- a/tests/test_main_trailing_config.py
+++ b/tests/test_main_trailing_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Dict
 
 import src.main as main_mod
@@ -45,3 +46,27 @@ def test_trailing_config_warns_on_non_positive_thresholds(monkeypatch, capsys):
     assert "giveback_ccy=-1.0" in captured.out
     assert trailing["arm_ccy"] == 0.0
     assert trailing["giveback_ccy"] == -1.0
+
+
+def test_format_trading_summary_uses_explicit_trade_counter_names():
+    snapshot = SimpleNamespace(
+        source="trades",
+        lifetime_closed_trades=42,
+        session_closed_trades=7,
+        wins=4,
+        losses=3,
+        loss_streak=2,
+        risk_multiplier=0.75,
+        filter_run_tag="MINI_RUN",
+        filter_window_start_utc="2026-03-30T00:00:00+00:00",
+        filter_window_end_utc="2026-03-30T01:00:00+00:00",
+    )
+
+    summary = main_mod._format_trading_summary(snapshot)
+
+    assert "lifetime_closed_trades=42" in summary
+    assert "session_closed_trades=7" in summary
+    assert " closed=" not in summary
+    assert "run_tag=MINI_RUN" in summary
+    assert "window_start_utc=2026-03-30T00:00:00+00:00" in summary
+    assert "window_end_utc=2026-03-30T01:00:00+00:00" in summary


### PR DESCRIPTION
### Motivation
- Prevent ambiguous mixed counters in summary logs by replacing a single `closed` counter with clearly scoped lifetime and session counters. 
- Expose the adaptive tuner filter basis so summaries state how the counters were derived (`source`, `run_tag`, date window). 
- Emit a one-time startup line showing both counters side-by-side to aid diagnostics at boot. 
- Add tests to lock in the new summary format and avoid regressions that allow ambiguous logging again. 

### Description
- Replace the single `closed_trades` field with `lifetime_closed_trades` and `session_closed_trades` on `AdaptiveSnapshot` and make construction compatibility-safe for older signatures. 
- Add filter metadata to snapshots: `filter_run_tag`, `filter_window_start_utc`, and `filter_window_end_utc`, and surface `source` (trades vs trade_events). 
- Add optional `run_tag` and `window_start_utc` inputs to `AdaptiveTuner`, make SQL queries/counts respect `run_tag` and window predicates when the `trades` table supports `run_tag`, and add `_count_trades` + `_trade_columns` helper for schema-safe counting. 
- Wire `main` to provide a default `ADAPTIVE_RUN_TAG` and a startup/day-bounded window, add `STARTUP_UTC` and `_adaptive_window_start_utc()`, introduce `_format_trading_summary()` for consistent `TRADING_SUMMARY` output, update `[JOURNAL]` prints in `heartbeat`, `startup` and `__main__` to emit explicit `lifetime_closed_trades` / `session_closed_trades` and the filter basis, and print a one-time `[JOURNAL][STARTUP]` line with both counters. 
- Update unit tests: adapt `tests/test_adaptive_tuner.py` for renamed counters and add `test_format_trading_summary_uses_explicit_trade_counter_names` in `tests/test_main_trailing_config.py` to validate summary formatting. 

### Testing
- Ran `pytest -q tests/test_adaptive_tuner.py tests/test_main_trailing_config.py` and observed all tests passing. 
- Result: `8 passed` (local run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca1c5464a883299d37a5132202c9c1)