### PR TITLE
Add per-instrument filter reason counters, periodic summaries, and XAU spread guardrails

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -23,6 +23,8 @@
   "xau_atr_guard_action": "skip",
   "xau_atr_guard_size_scale": 0.5,
   "xau_atr_guard_note": "Skip or scale position size when XAU_USD ATR exceeds baseline * guard ratio",
+  "filter_report_every_cycles": 60,
+  "filter_threshold_tolerance_cap_pips": 25.0,
   "use_macd_confirmation": true,
   "instruments": [
     "EUR_USD",
@@ -63,6 +65,9 @@
       "XAU_USD": 5.0
     },
     "default_spread_pips_limit": 2.5,
+    "xau_spread_pips_limit": 5.0,
+    "xau_spread_atr_ratio": 0.25,
+    "spread_limit_tolerance_cap_pips": 25.0,
     "rollover_quiet_awst": {
       "start": "04:55",
       "end": "05:05"

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 import json
 import os
 import inspect
@@ -574,6 +575,67 @@ suppression_counters = {
     "blocked_spread": 0,
 }
 
+FILTER_REPORT_EVERY_CYCLES = max(
+    1, int(os.getenv("FILTER_REPORT_EVERY_CYCLES", config.get("filter_report_every_cycles", 60)))
+)
+FILTER_THRESHOLD_TOLERANCE_CAP_PIPS = max(
+    0.1,
+    _coerce_float(
+        os.getenv(
+            "FILTER_THRESHOLD_TOLERANCE_CAP_PIPS",
+            config.get("filter_threshold_tolerance_cap_pips", 25.0),
+        ),
+        25.0,
+    ),
+)
+
+_reason_counts_by_instrument: dict[str, dict[str, int]] = defaultdict(lambda: defaultdict(int))
+_signal_counts_by_instrument: dict[str, int] = defaultdict(int)
+_decision_cycle_count = 0
+
+
+def _normalize_block_reason(reason: str | None) -> str:
+    cleaned = str(reason or "unknown").strip().lower().replace("_", "-")
+    return cleaned or "unknown"
+
+
+def _record_signal_evaluated(instrument: str) -> None:
+    _signal_counts_by_instrument[instrument] += 1
+
+
+def _record_block_reason(instrument: str, reason: str | None) -> None:
+    normalized = _normalize_block_reason(reason)
+    _reason_counts_by_instrument[instrument][normalized] += 1
+
+
+def _format_filter_block_summary_lines(cycle_count: int) -> list[str]:
+    lines: list[str] = []
+    for instrument in sorted(_signal_counts_by_instrument):
+        total = _signal_counts_by_instrument[instrument]
+        reasons = _reason_counts_by_instrument.get(instrument, {})
+        blocked = sum(reasons.values())
+        block_rate = (blocked / total) if total else 0.0
+        reason_clause = ",".join(
+            f"{reason}:{count}" for reason, count in sorted(reasons.items())
+        ) or "none"
+        lines.append(
+            f"[FILTER][SUMMARY] cycles={cycle_count} instrument={instrument} "
+            f"blocked={blocked} total={total} block_rate={block_rate:.1%} reasons={reason_clause}"
+        )
+    return lines
+
+
+def _maybe_emit_filter_block_summary(cycle_count: int) -> None:
+    if cycle_count <= 0 or cycle_count % FILTER_REPORT_EVERY_CYCLES != 0:
+        return
+    for line in _format_filter_block_summary_lines(cycle_count):
+        print(line, flush=True)
+
+
+def _reset_filter_block_stats() -> None:
+    _reason_counts_by_instrument.clear()
+    _signal_counts_by_instrument.clear()
+
 
 
 
@@ -960,6 +1022,7 @@ def _log_projector(evaluation: Evaluation, now_utc: datetime) -> None:
     )
 
 async def decision_cycle() -> None:
+    global _decision_cycle_count
     now_utc = datetime.now(timezone.utc)
     cycle_context = _new_cycle_context(now_utc, prefix="decision")
     tick_bucket = cycle_context["tick_bucket"]
@@ -1015,6 +1078,7 @@ async def decision_cycle() -> None:
         for evaluation in evaluations:
             cycle_stats["evaluations"] += 1
             suppression_counters["signals_generated"] += 1
+            _record_signal_evaluated(evaluation.instrument)
             log_cycle_event(
                 "DEBUG",
                 cycle_context,
@@ -1050,6 +1114,7 @@ async def decision_cycle() -> None:
 
             if not session_decision.allowed:
                 suppression_counters["blocked_off_session"] += 1
+                _record_block_reason(evaluation.instrument, session_decision.reason or "off-session")
                 cycle_stats["blocked_off_session"] += 1
                 cycle_stats["skipped"] += 1
                 ts = now_utc.astimezone(timezone.utc).strftime("%H:%M")
@@ -1062,6 +1127,7 @@ async def decision_cycle() -> None:
             should_trade, skip_reason = _should_place_trade(open_trades, evaluation)
             if not should_trade:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, skip_reason)
                 if skip_reason == "max-open":
                     suppression_counters["blocked_max_positions"] += 1
                     cycle_stats["blocked_max_positions"] += 1
@@ -1070,6 +1136,7 @@ async def decision_cycle() -> None:
             # Final broker-side duplicate guard before risk checks or order submission.
             if _instrument_open_on_broker(evaluation.instrument):
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, "broker-duplicate")
                 print(
                     f"[TRADE] Skipping {evaluation.instrument}; broker reports existing open position",
                     flush=True,
@@ -1088,9 +1155,11 @@ async def decision_cycle() -> None:
                 open_trades,
                 evaluation.instrument,
                 spread_pips,
+                atr_price_units=diagnostics.get("atr"),
             )
             if not ok_to_open:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, risk_reason)
                 print(
                     f"[TRADE] Skipping {evaluation.instrument} due to {risk_reason}",
                     flush=True,
@@ -1108,6 +1177,7 @@ async def decision_cycle() -> None:
 
             if getattr(risk, "demo_mode", False) and now_utc.weekday() >= 5:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, "weekend-lock")
                 print(
                     "[WEEKEND] Entry blocked - weekend lock active (UTC Saturday/Sunday)",
                     flush=True,
@@ -1121,6 +1191,7 @@ async def decision_cycle() -> None:
 
             if not trend_ok:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, "trend-misaligned")
                 print(
                     f"[FILTER] Trend misaligned {evaluation.instrument} signal={evaluation.signal} "
                     f"ema50={ema_trend_fast:.5f} ema200={ema_trend_slow:.5f}",
@@ -1141,6 +1212,8 @@ async def decision_cycle() -> None:
             )
             if xau_blocked or xau_guard_block:
                 cycle_stats["skipped"] += 1
+                xau_reason = "xau-rsi-atr-block" if xau_blocked else f"xau-guard-{xau_guard_reason}"
+                _record_block_reason(evaluation.instrument, xau_reason)
                 print(
                     f"[FILTER] XAU_USD blocked {evaluation.signal}: rsi={rsi_val:.2f} atr_ratio={atr_ratio:.2f} guard={xau_guard_reason} guard_atr={xau_atr_val:.5f} guard_ratio={xau_atr_ratio:.2f}",
                     flush=True,
@@ -1154,6 +1227,7 @@ async def decision_cycle() -> None:
             )
             if not macd_ok:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, "macd-veto")
                 print(
                     f"[FILTER] MACD veto {evaluation.instrument} macd={macd_line:.5f} "
                     f"signal={macd_signal_line:.5f} hist={macd_histogram:.5f}",
@@ -1173,6 +1247,7 @@ async def decision_cycle() -> None:
             )
             if not orb_ok:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, orb_reason or "orb-block")
                 print(
                     f"[FILTER] ORB block {evaluation.instrument} reason={orb_reason}",
                     flush=True,
@@ -1226,6 +1301,7 @@ async def decision_cycle() -> None:
             )
             if units <= 0:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, "zero-position-size")
                 print(
                     f"[TRADE] Skipping {evaluation.instrument} due to zero position size",
                     flush=True,
@@ -1305,12 +1381,15 @@ async def decision_cycle() -> None:
                 )
             else:
                 cycle_stats["skipped"] += 1
+                _record_block_reason(evaluation.instrument, "order-failed")
                 print(
                     f"[TRADE] Order failed instrument={evaluation.instrument} signal={evaluation.signal}"
                     f" response={result}",
                     flush=True,
                 )
     finally:
+        _decision_cycle_count += 1
+        _maybe_emit_filter_block_summary(_decision_cycle_count)
         if not _summary_already_emitted(tick_bucket):
             log_cycle_event(
                 "INFO",

--- a/src/risk_manager.py
+++ b/src/risk_manager.py
@@ -321,6 +321,7 @@ class RiskManager:
         open_positions: list,
         instrument: str,
         spread_pips: Optional[float],
+        atr_price_units: Optional[float] = None,
     ) -> Tuple[bool, str]:
         self._rollover(now_utc, equity)
         open_positions_count = len(open_positions) if open_positions is not None else None
@@ -384,7 +385,10 @@ class RiskManager:
         if self._in_rollover_window(now_utc):
             return False, "rollover-window"
 
-        spread_limit = self._spread_limit_for(instrument)
+        spread_limit = self._spread_limit_for(
+            instrument,
+            atr_price_units=atr_price_units,
+        )
         if spread_limit is not None and spread_pips is not None:
             if spread_pips > spread_limit:
                 return False, "spread-too-wide"
@@ -729,15 +733,53 @@ class RiskManager:
                 awst_now += timedelta(days=1)
         return start <= awst_now < end
 
-    def _spread_limit_for(self, instrument: str) -> Optional[float]:
+    def _spread_limit_for(
+        self,
+        instrument: str,
+        *,
+        atr_price_units: Optional[float] = None,
+    ) -> Optional[float]:
+        cap_limit = self._coerce_positive(
+            self.config.get(
+                "spread_limit_tolerance_cap_pips",
+                os.getenv("SPREAD_LIMIT_TOLERANCE_CAP_PIPS", 25.0),
+            ),
+            cap=None,
+        )
+        if cap_limit <= 0:
+            cap_limit = 25.0
+
+        xau_limit = self._xau_spread_limit(atr_price_units, cap_limit=cap_limit)
+        if instrument == "XAU_USD" and xau_limit is not None:
+            return xau_limit
+
         if instrument in self.spread_pips_limit:
-            return float(self.spread_pips_limit[instrument])
+            return min(float(self.spread_pips_limit[instrument]), cap_limit)
         if self.default_spread_limit is None:
             return None
         try:
-            return float(self.default_spread_limit)
+            return min(float(self.default_spread_limit), cap_limit)
         except (TypeError, ValueError):
             return None
+
+    def _xau_spread_limit(self, atr_price_units: Optional[float], *, cap_limit: float) -> Optional[float]:
+        raw_abs_limit = (
+            os.getenv("XAU_SPREAD_PIPS_LIMIT")
+            or self.config.get("xau_spread_pips_limit")
+            or self.spread_pips_limit.get("XAU_USD")
+        )
+        abs_limit = self._coerce_positive(raw_abs_limit, cap=None)
+
+        atr_ratio_raw = os.getenv("XAU_SPREAD_ATR_RATIO") or self.config.get("xau_spread_atr_ratio")
+        atr_ratio = self._coerce_positive(atr_ratio_raw, cap=None)
+        atr_relative_limit: Optional[float] = None
+        if atr_ratio > 0 and atr_price_units is not None and atr_price_units > 0:
+            atr_relative_limit = (atr_price_units / 0.01) * atr_ratio
+
+        candidates = [value for value in (abs_limit, atr_relative_limit) if value and value > 0]
+        if not candidates:
+            return None
+        return min(min(candidates), cap_limit)
 
     @staticmethod
     def _coerce_positive(value: object, *, cap: Optional[float] = None) -> float:

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -601,6 +601,38 @@ def test_decision_cycle_blocks_entries_on_weekend(monkeypatch, capsys):
         monkeypatch.setattr(main, "datetime", datetime)
 
 
+def test_filter_reason_counter_and_periodic_summary_format(capsys):
+    main._reset_filter_block_stats()
+    main._record_signal_evaluated("EUR_USD")
+    main._record_signal_evaluated("EUR_USD")
+    main._record_signal_evaluated("XAU_USD")
+    main._record_block_reason("EUR_USD", "spread-too-wide")
+    main._record_block_reason("EUR_USD", "inside-opening-range")
+    main._record_block_reason("XAU_USD", "trend-misaligned")
+
+    lines = main._format_filter_block_summary_lines(cycle_count=60)
+    assert len(lines) == 2
+    assert lines[0].startswith("[FILTER][SUMMARY] cycles=60 instrument=EUR_USD")
+    assert "block_rate=100.0%" in lines[0]
+    assert "reasons=inside-opening-range:1,spread-too-wide:1" in lines[0]
+    assert lines[1].startswith("[FILTER][SUMMARY] cycles=60 instrument=XAU_USD")
+    assert "block_rate=100.0%" in lines[1]
+    assert "reasons=trend-misaligned:1" in lines[1]
+
+    original_every = main.FILTER_REPORT_EVERY_CYCLES
+    try:
+        main.FILTER_REPORT_EVERY_CYCLES = 2
+        main._maybe_emit_filter_block_summary(cycle_count=1)
+        assert capsys.readouterr().out == ""
+        main._maybe_emit_filter_block_summary(cycle_count=2)
+        emitted = capsys.readouterr().out
+        assert "[FILTER][SUMMARY] cycles=2 instrument=EUR_USD" in emitted
+        assert "reasons=inside-opening-range:1,spread-too-wide:1" in emitted
+    finally:
+        main.FILTER_REPORT_EVERY_CYCLES = original_every
+        main._reset_filter_block_stats()
+
+
 def test_decision_cycle_allows_entries_inside_session(monkeypatch):
     class DummyRisk:
         risk_per_trade_pct = 0.001

--- a/tests/test_risk_manager.py
+++ b/tests/test_risk_manager.py
@@ -87,6 +87,41 @@ def test_cooldown_and_spread_limits(state_dir):
     assert ok is True
 
 
+def test_xau_spread_limit_supports_absolute_atr_relative_and_cap(state_dir):
+    manager = RiskManager(
+        {
+            "spread_pips_limit": {"XAU_USD": 5.0},
+            "xau_spread_pips_limit": 4.0,
+            "xau_spread_atr_ratio": 0.5,
+            "spread_limit_tolerance_cap_pips": 3.0,
+        },
+        mode="paper",
+    )
+    now = _utc(2024, 1, 1, 2, 0)
+
+    ok, reason = manager.should_open(
+        now,
+        10_000.0,
+        [],
+        "XAU_USD",
+        3.2,
+        atr_price_units=0.10,
+    )
+    assert ok is False
+    assert reason == "spread-too-wide"
+
+    ok, reason = manager.should_open(
+        now,
+        10_000.0,
+        [],
+        "XAU_USD",
+        2.9,
+        atr_price_units=0.10,
+    )
+    assert ok is True
+    assert reason == "ok"
+
+
 def test_daily_loss_cap_blocks_after_drawdown(state_dir):
     manager = RiskManager({"daily_loss_cap_pct": 0.01}, mode="paper")
     today = _utc(2024, 1, 1, 4, 0)


### PR DESCRIPTION
### Motivation

- Provide visibility into why signals are blocked by tracking per-instrument, per-reason counts for filter and risk gating paths.
- Emit periodic aggregated filter reports to measure block-rates and quickly surface problematic instruments or dominant reasons.
- Make XAU_USD spread gating configurable (absolute and ATR-relative) and ensure thresholds cannot exceed a safe tolerance cap.

### Description

- Added per-instrument counters and summary utilities in `src/main.py` including `_record_signal_evaluated`, `_record_block_reason`, `_format_filter_block_summary_lines`, `_maybe_emit_filter_block_summary`, and `_reset_filter_block_stats`, and wired counters into main `decision_cycle` across all skip/block paths (session, broker duplicate, risk, weekend, trend, XAU guards, MACD, ORB, zero-size, order-failed). (changes in `src/main.py`).
- Added cycle-based periodic reporting with configurable period via `FILTER_REPORT_EVERY_CYCLES` (env/config) and related default config keys in `config/defaults.json`.
- Passed ATR into risk gating from `decision_cycle` and extended `RiskManager.should_open` to accept `atr_price_units`, then implemented XAU-specific spread resolution in `src/risk_manager.py` supporting: an absolute override (`xau_spread_pips_limit` / `XAU_SPREAD_PIPS_LIMIT`), an ATR-relative limit (`xau_spread_atr_ratio` / `XAU_SPREAD_ATR_RATIO`), and a hard tolerance cap (`spread_limit_tolerance_cap_pips` / `SPREAD_LIMIT_TOLERANCE_CAP_PIPS`) that bounds returned spread thresholds; non-XAU limits are also clamped by the cap. (changes in `src/risk_manager.py` and call site in `src/main.py`).
- Added new defaults to `config/defaults.json` for `filter_report_every_cycles`, `filter_threshold_tolerance_cap_pips`, `xau_spread_pips_limit`, `xau_spread_atr_ratio`, and `spread_limit_tolerance_cap_pips`.
- Added unit tests: `test_filter_reason_counter_and_periodic_summary_format` (checks counters, formatting and emission behavior) and `test_xau_spread_limit_supports_absolute_atr_relative_and_cap` (validates XAU absolute + ATR-relative + cap behavior), plus minor test updates to integrate the changes. (changes in `tests/test_decider.py` and `tests/test_risk_manager.py`).

### Testing

- Ran the new targeted tests with `pytest -q tests/test_decider.py::test_filter_reason_counter_and_periodic_summary_format tests/test_risk_manager.py::test_xau_spread_limit_supports_absolute_atr_relative_and_cap tests/test_risk_manager.py::test_cooldown_and_spread_limits` and they passed (`3 passed`).
- Ran the related module suites with `pytest -q tests/test_decider.py tests/test_risk_manager.py` and observed all tests passing (`42 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca1f02a48c8329812bda8418387474)