### PR TITLE
Apply XAU guard scale to effective risk sizing and add audit logging/tests

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1390,10 +1390,32 @@ async def decision_cycle() -> None:
                 )
                 continue
 
+            base_risk_pct = float(risk.risk_per_trade_pct)
             adaptive_snap = _safe_adaptive_snapshot("decision_cycle")
-            effective_risk_pct = risk.risk_per_trade_pct
+            adaptive_risk_pct = base_risk_pct
             if adaptive_snap is not None:
-                effective_risk_pct = max(0.001, min(0.025, risk.risk_per_trade_pct * adaptive_snap.risk_multiplier))
+                adaptive_risk_pct = max(
+                    0.001,
+                    min(0.025, base_risk_pct * adaptive_snap.risk_multiplier),
+                )
+
+            xau_scale_active = (
+                evaluation.instrument == "XAU_USD" and xau_guard_reason == "scale" and xau_risk_scale > 0.0
+            )
+            effective_risk_pct = adaptive_risk_pct
+            if xau_scale_active:
+                effective_risk_pct = max(
+                    0.001,
+                    min(0.025, adaptive_risk_pct * xau_risk_scale),
+                )
+
+            print(
+                f"[RISK] {evaluation.instrument} base_pct={base_risk_pct:.6f} "
+                f"adaptive_pct={adaptive_risk_pct:.6f} "
+                f"xau_final_pct={effective_risk_pct:.6f} "
+                f"xau_guard={xau_guard_reason} xau_scale={xau_risk_scale:.3f}",
+                flush=True,
+            )
 
             try:
                 size_result = position_sizer.units_for_risk(

--- a/tests/test_filters_v161.py
+++ b/tests/test_filters_v161.py
@@ -266,3 +266,95 @@ def test_off_session_blocks_entries_but_trailing_runs(monkeypatch, capsys):
     finally:
         watchdog.last_decision_ts = original_ts
         _reset_clock(original_datetime)
+
+
+def test_xau_guard_scale_reduces_position_units(monkeypatch):
+    class DummyRisk:
+        risk_per_trade_pct = 0.01
+        demo_mode = False
+
+        def enforce_equity_floor(self, *args, **kwargs):
+            pass
+
+        def should_open(self, *args, **kwargs):
+            return True, "ok"
+
+        def sl_distance_from_atr(self, atr, instrument=None):
+            return 0.5
+
+        def register_entry(self, now_utc, instrument: str):
+            pass
+
+        def register_exit(self, *args, **kwargs):
+            pass
+
+    class DummyEngine:
+        def __init__(self) -> None:
+            self.atr = 1.0
+
+        def evaluate_all(self) -> List[Evaluation]:
+            return [
+                Evaluation(
+                    instrument="XAU_USD",
+                    signal="BUY",
+                    diagnostics={
+                        "atr": self.atr,
+                        "atr_baseline_50": 1.0,
+                        "rsi": 60.0,
+                        "close": 1900.0,
+                        "ema_trend_fast": 1910.0,
+                        "ema_trend_slow": 1900.0,
+                    },
+                    reason="trend",
+                    market_active=True,
+                )
+            ]
+
+        def mark_trade(self, instrument: str) -> None:
+            pass
+
+    class DummyBroker:
+        def __init__(self) -> None:
+            self.calls: List[Dict[str, object]] = []
+
+        def place_order(self, instrument: str, signal: str, units: int, *args, **kwargs):
+            self.calls.append({"instrument": instrument, "signal": signal, "units": units})
+            return {"status": "SENT"}
+
+        def account_equity(self) -> float:
+            return 10_000.0
+
+        def current_spread(self, instrument: str) -> float:
+            return 0.5
+
+        def close_all_positions(self) -> None:
+            pass
+
+    dummy_engine = DummyEngine()
+    dummy_broker = DummyBroker()
+    monkeypatch.setattr(main, "engine", dummy_engine)
+    monkeypatch.setattr(main, "broker", dummy_broker)
+    monkeypatch.setattr(main, "risk", DummyRisk())
+    monkeypatch.setattr(main, "profit_guard", type("PG", (), {"process_open_trades": lambda self, trades: []})())
+    monkeypatch.setattr(main, "_open_trades_state", lambda: [])
+    monkeypatch.setattr(main.session_filter, "session_decision", lambda *args, **kwargs: _allow_session_decision())
+    monkeypatch.setattr(main, "_orb_filter", lambda *args, **kwargs: (True, None, None))
+    monkeypatch.setattr(main, "_macd_confirms", lambda *args, **kwargs: (True, 0.0, 0.0, 0.0))
+    monkeypatch.setattr(main, "_safe_adaptive_snapshot", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        main.position_sizer,
+        "units_for_risk",
+        lambda *args, **kwargs: int(args[3] * 1_000_000),
+    )
+    monkeypatch.setitem(main.config, "xau_atr_guard_ratio", 1.2)
+    monkeypatch.setitem(main.config, "xau_atr_guard_action", "scale")
+    monkeypatch.setitem(main.config, "xau_atr_guard_size_scale", 0.5)
+
+    asyncio.run(main.decision_cycle())
+    baseline_units = dummy_broker.calls[-1]["units"]
+
+    dummy_engine.atr = 1.8
+    asyncio.run(main.decision_cycle())
+    scaled_units = dummy_broker.calls[-1]["units"]
+
+    assert scaled_units < baseline_units


### PR DESCRIPTION
### Motivation
- Ensure the XAU ATR guard `scale` action reduces effective trade risk instead of only influencing blocking logic. 
- Make risk calculation auditable by surfacing the base, adaptive-adjusted, and final XAU-adjusted risk values in the order path. 
- Provide automated coverage that verifies `scale` mode actually reduces position units versus a baseline.

### Description
- Compute `base_risk_pct` from `risk.risk_per_trade_pct`, derive `adaptive_risk_pct` from the adaptive snapshot, and then apply the XAU scale multiplier to produce `effective_risk_pct` only when the XAU guard action is `scale`, clamping values to the existing safety bounds (`0.001`..`0.025`) in `decision_cycle` (`src/main.py`).
- Add an audit log line in the order path emitting `base_pct`, `adaptive_pct`, `xau_final_pct`, `xau_guard`, and `xau_scale` for traceability during decision execution. 
- Add a new test `test_xau_guard_scale_reduces_position_units` in `tests/test_filters_v161.py` that runs a baseline and a scaled scenario to assert scaled units are lower when the XAU guard triggers `scale` mode.

### Testing
- Ran `pytest -q tests/test_filters_v161.py` and the suite passed with `3 passed`.
- The new test demonstrates that XAU `scale` action reduces produced position units compared to the baseline scenario.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5400f00c8329ae1693319279b1c2)