### PR TITLE
Make take-profit distance config-driven in decision cycle

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -437,6 +437,7 @@ risk_config["sl_atr_mult"] = float(os.getenv("SL_ATR_MULT", os.getenv("ATR_STOP_
 risk_config["tp_atr_mult"] = float(os.getenv("TP_ATR_MULT", tp_default))
 risk_config.setdefault("instrument_atr_multipliers", risk_config.get("instrument_atr_multipliers", config.get("instrument_atr_multipliers", {})))
 risk_config.setdefault("tp_rr_multiple", risk_config["tp_atr_mult"])
+risk_config.setdefault("tp_enabled", _as_bool(os.getenv("TP_ENABLED", risk_config.get("tp_enabled", config.get("tp_enabled", True)))))
 risk_config.setdefault("cooldown_candles", int(os.getenv("COOLDOWN_CANDLES", risk_config.get("cooldown_candles", 9))))
 env_max_positions = os.getenv("MAX_CONCURRENT_POSITIONS") or os.getenv("MAX_OPEN_TRADES")
 max_positions_default = risk_config.get("max_concurrent_positions", config.get("max_open_trades", 3))
@@ -491,6 +492,12 @@ config["aggressive_max_hold_minutes"] = aggressive_max_hold_minutes
 config["aggressive_max_loss_ccy"] = aggressive_max_loss_ccy
 config["aggressive_max_loss_atr_mult"] = aggressive_max_loss_atr_mult
 config["risk"] = risk_config
+print(
+    f"[CONFIG] tp enabled={bool(risk_config.get('tp_enabled', True))} "
+    f"tp_atr_mult={float(risk_config.get('tp_atr_mult', 0.0)):.4f} "
+    f"tp_rr_multiple={float(risk_config.get('tp_rr_multiple', risk_config.get('tp_atr_mult', 0.0))):.4f}",
+    flush=True,
+)
 
 # Abort if live is requested (demo/practice only)
 oanda_env = (os.getenv("OANDA_ENV") or "practice").lower()
@@ -1322,7 +1329,12 @@ async def decision_cycle() -> None:
 
             atr_val = diagnostics.get("atr")
             sl_distance = risk.sl_distance_from_atr(atr_val, instrument=evaluation.instrument)
-            tp_distance = 0.0  # Disable standard TP to avoid interfering with account-currency profit protection
+            tp_enabled = bool(config.get("risk", {}).get("tp_enabled", True))
+            tp_distance = (
+                risk.tp_distance_from_atr(atr_val, instrument=evaluation.instrument)
+                if tp_enabled
+                else 0.0
+            )
             entry_price = diagnostics.get("close")
 
             if not trend_ok:

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -239,6 +239,7 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
     dummy_engine = DummyEngine()
     dummy_broker = DummyBroker()
     dummy_risk = DummyRisk()
+    monkeypatch.setitem(main.config["risk"], "tp_enabled", True)
     monkeypatch.setattr(main, "engine", dummy_engine)
     monkeypatch.setattr(main, "broker", dummy_broker)
     monkeypatch.setattr(main, "_open_trades_state", lambda: [])
@@ -260,13 +261,14 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
     try:
         assert dummy_engine.marked == ["EUR_USD"]
         expected_sl = dummy_risk.sl_distance_from_atr(0.01)
+        expected_tp = dummy_risk.tp_distance_from_atr(0.01)
         assert dummy_broker.calls == [
             {
                 "instrument": "EUR_USD",
                 "signal": "BUY",
                 "units": 100,
                 "sl_distance": expected_sl,
-                "tp_distance": 0.0,
+                "tp_distance": expected_tp,
                 "entry_price": 1.2345,
             }
         ]
@@ -275,6 +277,96 @@ def test_decision_cycle_updates_watchdog_on_success(monkeypatch):
     finally:
         watchdog.last_decision_ts = original_ts
         monkeypatch.setattr(main, "datetime", datetime)
+
+
+def test_decision_cycle_keeps_tp_disabled_when_configured(monkeypatch):
+    class DummyRisk:
+        risk_per_trade_pct = 0.001
+
+        def enforce_equity_floor(self, *args, **kwargs) -> None:
+            pass
+
+        def should_open(self, *args, **kwargs):
+            return True, "ok"
+
+        def sl_distance_from_atr(self, atr, instrument=None):
+            return 0.01 if atr else 0.0
+
+        def tp_distance_from_atr(self, atr, instrument=None):
+            return 0.02 if atr else 0.0
+
+        def register_entry(self, *args, **kwargs) -> None:
+            pass
+
+        def register_exit(self, realized_pl: float) -> None:
+            pass
+
+    class DummyEngine:
+        def evaluate_all(self) -> List[Evaluation]:
+            return [
+                Evaluation(
+                    instrument="EUR_USD",
+                    signal="BUY",
+                    diagnostics={
+                        "atr": 0.01,
+                        "atr_baseline_50": 0.01,
+                        "close": 1.2345,
+                        "ema_trend_fast": 1.25,
+                        "ema_trend_slow": 1.2,
+                    },
+                    reason="trend",
+                    market_active=True,
+                    candles=[
+                        {"o": 1.0, "h": 1.05, "l": 0.99, "c": 1.01},
+                        {"o": 1.01, "h": 1.07, "l": 1.0, "c": 1.04},
+                        {"o": 1.04, "h": 1.08, "l": 1.02, "c": 1.06},
+                    ],
+                )
+            ]
+
+        def mark_trade(self, instrument: str) -> None:
+            pass
+
+    class DummyBroker:
+        def __init__(self) -> None:
+            self.calls: List[Dict[str, object]] = []
+
+        def place_order(
+            self,
+            instrument: str,
+            signal: str,
+            units: int,
+            *,
+            sl_distance: float | None = None,
+            tp_distance: float | None = None,
+            entry_price: float | None = None,
+        ) -> Dict[str, str]:
+            self.calls.append({"tp_distance": tp_distance})
+            return {"status": "SENT"}
+
+        def account_equity(self) -> float:
+            return 10_000.0
+
+        def current_spread(self, instrument: str) -> float:
+            return 0.5
+
+    monkeypatch.setitem(main.config["risk"], "tp_enabled", False)
+    monkeypatch.setattr(main, "engine", DummyEngine())
+    broker = DummyBroker()
+    monkeypatch.setattr(main, "broker", broker)
+    monkeypatch.setattr(main, "_open_trades_state", lambda: [])
+    monkeypatch.setattr(main, "risk", DummyRisk())
+    monkeypatch.setattr(main.session_filter, "session_decision", lambda *args, **kwargs: _allow_session_decision())
+    monkeypatch.setattr(
+        main.position_sizer,
+        "units_for_risk",
+        lambda equity, entry_price, stop_distance, risk_pct: 100,
+    )
+
+    asyncio.run(main.decision_cycle())
+
+    assert broker.calls
+    assert broker.calls[0]["tp_distance"] == 0.0
 
 
 def test_decision_cycle_updates_watchdog_on_error(monkeypatch):


### PR DESCRIPTION
### Motivation
- Remove the hard-coded take-profit (`tp_distance = 0.0`) so TP behavior can follow existing ATR-based risk configuration and be explicitly opted-out when desired.

### Description
- Add `risk.tp_enabled` configuration with environment override `TP_ENABLED` and default to enabled, and log TP status and active multipliers at startup in `src/main.py`.
- Compute `tp_distance` in `decision_cycle` via `risk.tp_distance_from_atr(...)` when `tp_enabled` is true, otherwise keep `tp_distance` at `0.0`.
- Preserve existing ATR multiplier wiring (`tp_atr_mult` / `tp_rr_multiple`) and leave profit-protection logic untouched.
- Update tests in `tests/test_decider.py` to assert both TP-enabled and TP-disabled paths reach the broker with the expected `tp_distance` values.

### Testing
- Ran `pytest -q tests/test_decider.py -k "watchdog_on_success or keeps_tp_disabled"` which passed (`2 passed, 18 deselected`).
- Ran `pytest -q tests/test_decider.py` which passed (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb540954d0832987c3c92f03cf0725)