### PR TITLE
Cache open-trades snapshot to reduce broker polling in decision cycle and health

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -513,7 +513,7 @@ async def heartbeat() -> None:
 
     ts_local = now_utc.astimezone().isoformat()
     equity = broker.account_equity()
-    open_count = len(_open_trades_state())
+    open_count = len(_open_trades_state(force_refresh=False))
 
     journal_path = journal.path
     journal_exists = journal_path.exists()
@@ -688,6 +688,12 @@ CYCLE_HEALTH = CycleHealthTracker(
     summary_interval_seconds=int(_coerce_float(os.getenv("CYCLE_HEALTH_LOG_INTERVAL_SECONDS", "900"), 900.0)),
 )
 _LAST_BROKER_SYNC_TS: datetime | None = None
+_LAST_OPEN_TRADES_SNAPSHOT: List[Dict] = []
+_LAST_OPEN_TRADES_TS: datetime | None = None
+_OPEN_TRADES_CACHE_TTL_SECONDS = max(
+    1.0,
+    _coerce_float(os.getenv("OPEN_TRADES_CACHE_TTL_SECONDS", "15"), 15.0),
+)
 _SCHEDULER_REF: AsyncIOScheduler | None = None
 
 
@@ -768,7 +774,7 @@ def _startup_checks() -> None:
         return
 
     try:
-        open_trades = _open_trades_state()
+        open_trades = _open_trades_state(force_refresh=True)
         open_count = len(open_trades or [])
     except Exception as exc:  # pragma: no cover - defensive
         print(f"[STARTUP-RESET][WARN] Unable to inspect open trades: {exc}", flush=True)
@@ -805,15 +811,23 @@ def _startup_checks() -> None:
             print("[RISK] RESET_WEEKLY_LOSS_CAP requested but no weekly baseline changes were needed", flush=True)
 
 
-def _open_trades_state() -> List[Dict]:
-    global _LAST_BROKER_SYNC_TS
+def _open_trades_state(*, force_refresh: bool = True) -> List[Dict]:
+    global _LAST_BROKER_SYNC_TS, _LAST_OPEN_TRADES_TS, _LAST_OPEN_TRADES_SNAPSHOT
+    if not force_refresh and _LAST_OPEN_TRADES_TS is not None:
+        age = _age_seconds(_LAST_OPEN_TRADES_TS)
+        if age is not None and age <= _OPEN_TRADES_CACHE_TTL_SECONDS:
+            return list(_LAST_OPEN_TRADES_SNAPSHOT)
     try:
         trades = broker.list_open_trades()
         _LAST_BROKER_SYNC_TS = _utc_now()
-        return trades
+        _LAST_OPEN_TRADES_TS = _LAST_BROKER_SYNC_TS
+        _LAST_OPEN_TRADES_SNAPSHOT = list(trades or [])
+        return list(_LAST_OPEN_TRADES_SNAPSHOT)
     except AttributeError:
         # Older broker implementations may not yet expose list_open_trades.
         _LAST_BROKER_SYNC_TS = _utc_now()
+        _LAST_OPEN_TRADES_TS = _LAST_BROKER_SYNC_TS
+        _LAST_OPEN_TRADES_SNAPSHOT = []
         return []
     except Exception as exc:
         _LAST_BROKER_SYNC_TS = _utc_now()
@@ -876,7 +890,7 @@ def _age_seconds(ts: datetime | None, now_utc: datetime | None = None) -> float 
 
 def _health_status(now_utc: datetime | None = None) -> Dict:
     now = now_utc or _utc_now()
-    open_count = len(_open_trades_state())
+    open_count = len(_open_trades_state(force_refresh=False))
     return {
         "scheduler_alive": _scheduler_alive(),
         "last_cycle_age_sec": CYCLE_HEALTH.cycle_age_seconds(now),
@@ -885,14 +899,17 @@ def _health_status(now_utc: datetime | None = None) -> Dict:
     }
 
 
-def _instrument_open_on_broker(instrument: str) -> bool:
+def _instrument_open_on_broker(instrument: str, open_trades: List[Dict] | None = None) -> bool:
     """Cross-check broker state to prevent duplicate exposure."""
 
-    try:
-        trades = broker.list_open_trades()
-    except Exception as exc:
-        print(f"[TRADE][WARN] Unable to verify broker positions for {instrument}: {exc}", flush=True)
-        return False
+    if open_trades is None:
+        try:
+            trades = broker.list_open_trades()
+        except Exception as exc:
+            print(f"[TRADE][WARN] Unable to verify broker positions for {instrument}: {exc}", flush=True)
+            return False
+    else:
+        trades = open_trades
 
     for trade in trades or []:
         if trade.get("instrument") == instrument:
@@ -1270,7 +1287,7 @@ async def decision_cycle() -> None:
                 continue
 
             # Final broker-side duplicate guard before risk checks or order submission.
-            if _instrument_open_on_broker(evaluation.instrument):
+            if _instrument_open_on_broker(evaluation.instrument, open_trades=open_trades):
                 cycle_stats["skipped"] += 1
                 _record_block_reason(evaluation.instrument, "broker-duplicate")
                 print(

--- a/tests/test_decider.py
+++ b/tests/test_decider.py
@@ -979,6 +979,91 @@ def test_fetch_candles_does_not_retry_on_client_error(capfd, sample_config):
     assert "[WARN] EUR_USD fetch failed 400 – skipping" in captured
 
 
+def test_instrument_open_on_broker_prefetched_snapshot_skips_broker_call(monkeypatch):
+    calls = {"list_open_trades": 0}
+
+    class DummyBroker:
+        def list_open_trades(self):
+            calls["list_open_trades"] += 1
+            return [{"instrument": "EUR_USD"}]
+
+    monkeypatch.setattr(main, "broker", DummyBroker())
+
+    assert main._instrument_open_on_broker(
+        "EUR_USD",
+        open_trades=[{"instrument": "EUR_USD"}],
+    )
+    assert calls["list_open_trades"] == 0
+
+
+def test_decision_cycle_fetches_open_trades_once_for_duplicate_checks(monkeypatch):
+    class DummyEngine:
+        def evaluate_all(self) -> List[Evaluation]:
+            return [
+                Evaluation(
+                    instrument="EUR_USD",
+                    signal="BUY",
+                    diagnostics={"ema_trend_fast": 2.0, "ema_trend_slow": 1.0},
+                    reason="trend",
+                    market_active=True,
+                    candles=[{"o": 1.0, "h": 1.0, "l": 1.0, "c": 1.0}],
+                )
+            ]
+
+    class DummyRisk:
+        risk_per_trade_pct = 0.001
+        demo_mode = False
+
+        def enforce_equity_floor(self, *args, **kwargs):
+            pass
+
+        def should_open(self, *args, **kwargs):
+            return True, "ok"
+
+        def sl_distance_from_atr(self, atr, instrument=None):
+            return 0.01
+
+        def register_entry(self, *args, **kwargs):
+            pass
+
+    class DummyBroker:
+        def __init__(self) -> None:
+            self.list_calls = 0
+            self.place_calls = 0
+
+        def account_equity(self) -> float:
+            return 10_000.0
+
+        def list_open_trades(self):
+            self.list_calls += 1
+            return [{"instrument": "EUR_USD", "id": "existing"}]
+
+        def current_spread(self, instrument: str) -> float:
+            return 0.1
+
+        def close_all_positions(self) -> None:
+            pass
+
+        def place_order(self, *args, **kwargs):
+            self.place_calls += 1
+            return {"status": "SENT"}
+
+    dummy_broker = DummyBroker()
+    monkeypatch.setattr(main, "engine", DummyEngine())
+    monkeypatch.setattr(main, "risk", DummyRisk())
+    monkeypatch.setattr(main, "broker", dummy_broker)
+    monkeypatch.setattr(main, "profit_guard", type("PG", (), {"process_open_trades": lambda self, trades: []})())
+    monkeypatch.setattr(main.session_filter, "session_decision", lambda *args, **kwargs: _allow_session_decision())
+    monkeypatch.setattr(main, "_safe_adaptive_snapshot", lambda context: None)
+    monkeypatch.setattr(main, "_macd_confirms", lambda *args, **kwargs: (True, 0.0, 0.0, 0.0))
+    monkeypatch.setattr(main, "_orb_filter", lambda *args, **kwargs: (True, None, {}))
+
+    asyncio.run(main.decision_cycle())
+
+    assert dummy_broker.list_calls == 1
+    assert dummy_broker.place_calls == 0
+
+
 def test_resolve_instruments_normalizes_input(sample_config):
     config = {
         **sample_config,

--- a/tests/test_main_cycle_health.py
+++ b/tests/test_main_cycle_health.py
@@ -29,3 +29,25 @@ def test_cycle_percentiles_and_summary_interval_with_controlled_time():
     assert tracker.should_emit_summary(t0) is True
     assert tracker.should_emit_summary(t0 + timedelta(minutes=10)) is False
     assert tracker.should_emit_summary(t0 + timedelta(minutes=16)) is True
+
+
+def test_health_status_uses_cached_open_trades_snapshot(monkeypatch):
+    class DummyBroker:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def list_open_trades(self):
+            self.calls += 1
+            return [{"instrument": "EUR_USD"}]
+
+    broker = DummyBroker()
+    monkeypatch.setattr(main_mod, "broker", broker)
+    monkeypatch.setattr(main_mod, "_LAST_OPEN_TRADES_TS", None)
+    monkeypatch.setattr(main_mod, "_LAST_OPEN_TRADES_SNAPSHOT", [])
+
+    first = main_mod._health_status()
+    second = main_mod._health_status()
+
+    assert first["open_trades_count"] == 1
+    assert second["open_trades_count"] == 1
+    assert broker.calls == 1


### PR DESCRIPTION
### Motivation

- Minimize broker API calls caused by per-instrument duplicate checks and frequent health/heartbeat polling by reusing a short-lived snapshot of open trades.

### Description

- Add a short-lived open-trades snapshot cache (`_LAST_OPEN_TRADES_SNAPSHOT`, `_LAST_OPEN_TRADES_TS`) with TTL configurable via `OPEN_TRADES_CACHE_TTL_SECONDS` and update `_open_trades_state` to optionally honor cached data via `force_refresh` and populate the snapshot on refresh. 
- Change `_instrument_open_on_broker` to accept an optional `open_trades` argument and only call the broker when a pre-fetched snapshot is not provided. 
- Update `decision_cycle` to fetch open trades once at cycle start (`open_trades = _open_trades_state()`) and pass that snapshot into `_instrument_open_on_broker` for duplicate checks, avoiding repeated broker queries per instrument. 
- Update `heartbeat` and `_health_status` to use cached reads (`_open_trades_state(force_refresh=False)`) so status/heartbeat polling does not always trigger a broker sync. 
- Add unit tests covering the behavior and ensuring the reduction in broker calls does not change decision logic: `test_instrument_open_on_broker_prefetched_snapshot_skips_broker_call`, `test_decision_cycle_fetches_open_trades_once_for_duplicate_checks`, and `test_health_status_uses_cached_open_trades_snapshot`.

### Testing

- Ran the new and related unit tests: `pytest -q tests/test_decider.py::test_instrument_open_on_broker_prefetched_snapshot_skips_broker_call tests/test_decider.py::test_decision_cycle_fetches_open_trades_once_for_duplicate_checks tests/test_main_cycle_health.py::test_health_status_uses_cached_open_trades_snapshot`, which all passed. 
- Ran a broader test set: `pytest -q tests/test_decider.py tests/test_main_cycle_health.py`, and the suite passed (`24 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cb5411b71c8329afbe25611fb921c8)